### PR TITLE
Refactor load_icgem_gdf and simplify coordinates

### DIFF
--- a/harmonica/io.py
+++ b/harmonica/io.py
@@ -10,13 +10,11 @@ def load_icgem_gdf(fname, **kwargs):
     """
     Reads data from an ICGEM .gdf file.
 
-    The `ICGEM Calculation Service
-    <http://icgem.gfz-potsdam.de/>`__ [BarthelmesKohler2016]_
-    generates gravity field grids from spherical harmonic models.
-    They use a custom ASCII grid format with information in the header.
-    This function can read the format and parse information from the header.
-    It returns the data in a :class:`xarray.Dataset` for convenience and
-    reduced storage requirements.
+    The `ICGEM Calculation Service <http://icgem.gfz-potsdam.de/>`__
+    [BarthelmesKohler2016]_ generates gravity field grids from spherical harmonic
+    models. They use a custom ASCII grid format with information in the header. This
+    function can read the format and parse information from the header. It returns the
+    data in a :class:`xarray.Dataset` for convenience and reduced storage requirements.
 
     Parameters
     ----------
@@ -28,61 +26,46 @@ def load_icgem_gdf(fname, **kwargs):
 
     Returns
     -------
-    icgem_ds : :class:`xarray.Dataset`
+    grid : :class:`xarray.Dataset`
         An :class:`xarray.Dataset` with the data from the file. The header of the gdf
-        file is passed into the ``attr`` argument of the :class:`xarray.Dataset`.
+        file is available through the ``attr`` attribute of the :class:`xarray.Dataset`.
+
     """
-    if "usecols" not in kwargs:
-        kwargs["usecols"] = None
     rawdata, metadata = _read_gdf_file(fname, **kwargs)
-    shape = (metadata["latitude_parallels"], metadata["longitude_parallels"])
-    area = [
-        metadata["latlimit_south"],
-        metadata["latlimit_north"],
-        metadata["longlimit_west"],
-        metadata["longlimit_east"],
-    ]
-    attributes = metadata["attributes"]
-    if kwargs["usecols"] is not None:
-        attributes = [attributes[i] for i in kwargs["usecols"]]
-    if len(attributes) != rawdata.shape[0]:
-        raise IOError(
-            "Number of attributes ({}) and data columns ({}) mismatch".format(
-                len(attributes), rawdata.shape[0]
-            )
-        )
-
-    # Create xarray.Dataset
-    icgem_ds = xr.Dataset()
-    icgem_ds.attrs = metadata
-    for attr, value in zip(attributes, rawdata):
-        # Need to invert the data matrices in latitude "[::-1]"
-        # because the ICGEM grid gets varies latitude from N to S
-        value = value.reshape(shape)[::-1]
-        if attr == "latitude":
-            icgem_ds.coords["lat"] = (("northing", "easting"), value)
-        elif attr == "longitude":
-            icgem_ds.coords["lon"] = (("northing", "easting"), value)
-        else:
-            icgem_ds[attr] = (("northing", "easting"), value)
-    if "height_over_ell" in metadata and "height" not in attributes:
+    shape = (int(metadata["latitude_parallels"]), int(metadata["longitude_parallels"]))
+    data = dict(zip(metadata["attributes"], rawdata))
+    coords = {"longitude": data["longitude"].reshape(shape)[0, :],
+              "latitude": data["latitude"].reshape(shape)[:, 0][::-1]}
+    dims = ["latitude", "longitude"]
+    data_vars = {
+        name: (dims, value.reshape(shape)[::-1]) for name, value in data.items()
+        if name not in dims
+    }
+    # If the grid is at constant height, add the height as a matrix for convenience
+    # (otherwise, would have to parse from the attrs)
+    if "height_over_ell" in metadata:
         height = float(metadata["height_over_ell"].split()[0])
-        icgem_ds["height"] = (("northing", "easting"), height * np.ones(shape))
-
+        data_vars["height_over_ell"] = (dims, np.full(shape, height))
+    grid = xr.Dataset(data_vars, coords=coords, attrs=metadata)
     # Check area from header equals to area from data in cols
+    area = [
+        float(metadata["latlimit_south"]),
+        float(metadata["latlimit_north"]),
+        float(metadata["longlimit_west"]),
+        float(metadata["longlimit_east"]),
+    ]
     area_from_cols = (
-        icgem_ds.lat.values.min(),
-        icgem_ds.lat.values.max(),
-        icgem_ds.lon.values.min(),
-        icgem_ds.lon.values.max(),
+        grid.latitude.values.min(),
+        grid.latitude.values.max(),
+        grid.longitude.values.min(),
+        grid.longitude.values.max(),
     )
     if not np.allclose(area, area_from_cols):
-        errline = (
+        raise IOError(
             "Grid area read ({}) and calculated from attributes "
             "({}) mismatch.".format(area, area_from_cols)
         )
-        raise IOError(errline)
-    return icgem_ds
+    return grid
 
 
 def _read_gdf_file(fname, **kwargs):
@@ -109,11 +92,20 @@ def _read_gdf_file(fname, **kwargs):
                     metadata["attributes_units"] = line.strip().split()
         # Read the numerical values
         rawdata = np.loadtxt(gdf_file, ndmin=2, unpack=True, **kwargs)
-    _check_integrity(metadata)
+    _check_gdf_integrity(metadata)
+    # Remove column names from the metadata if they weren't read
+    if kwargs.get("usecols", None) is not None:
+        metadata["attributes"] = [metadata["attributes"][i] for i in kwargs["usecols"]]
+    if len(metadata["attributes"]) != rawdata.shape[0]:
+        raise IOError(
+            "Number of attributes ({}) and data columns ({}) mismatch".format(
+                len(metadata["attributes"]), rawdata.shape[0]
+            )
+        )
     return rawdata, metadata
 
 
-def _check_integrity(metadata):
+def _check_gdf_integrity(metadata):
     "Check the integrity of ICGEM gdf file metadata."
     needed_args = [
         "latitude_parallels",
@@ -128,9 +120,9 @@ def _check_integrity(metadata):
     for arg in needed_args:
         if arg in metadata:
             if "limit" in arg:
-                metadata[arg] = float(metadata[arg].split()[0])
+                metadata[arg] = metadata[arg].split()[0]
             else:
-                metadata[arg] = int(metadata[arg].split()[0])
+                metadata[arg] = metadata[arg].split()[0]
         else:
             raise IOError("Couldn't read {} field from gdf file header".format(arg))
     if "attributes" not in metadata:
@@ -152,7 +144,7 @@ def _check_integrity(metadata):
         if arg not in metadata["attributes"]:
             raise IOError("Couldn't find {} column.".format(arg))
     # Check proper values for shape and size
-    shape = (metadata["latitude_parallels"], metadata["longitude_parallels"])
-    size = metadata["number_of_gridpoints"]
+    shape = (int(metadata["latitude_parallels"]), int(metadata["longitude_parallels"]))
+    size = int(metadata["number_of_gridpoints"])
     if shape[0] * shape[1] != size:
         raise IOError("Grid shape '{}' and size '{}' mismatch.".format(shape, size))

--- a/harmonica/io.py
+++ b/harmonica/io.py
@@ -34,11 +34,14 @@ def load_icgem_gdf(fname, **kwargs):
     rawdata, metadata = _read_gdf_file(fname, **kwargs)
     shape = (int(metadata["latitude_parallels"]), int(metadata["longitude_parallels"]))
     data = dict(zip(metadata["attributes"], rawdata))
-    coords = {"longitude": data["longitude"].reshape(shape)[0, :],
-              "latitude": data["latitude"].reshape(shape)[:, 0][::-1]}
+    coords = {
+        "longitude": data["longitude"].reshape(shape)[0, :],
+        "latitude": data["latitude"].reshape(shape)[:, 0][::-1],
+    }
     dims = ["latitude", "longitude"]
     data_vars = {
-        name: (dims, value.reshape(shape)[::-1]) for name, value in data.items()
+        name: (dims, value.reshape(shape)[::-1])
+        for name, value in data.items()
         if name not in dims
     }
     # If the grid is at constant height, add the height as a matrix for convenience
@@ -119,10 +122,7 @@ def _check_gdf_integrity(metadata):
     # Check for needed arguments in metadata dictionary
     for arg in needed_args:
         if arg in metadata:
-            if "limit" in arg:
-                metadata[arg] = metadata[arg].split()[0]
-            else:
-                metadata[arg] = metadata[arg].split()[0]
+            metadata[arg] = metadata[arg].split()[0]
         else:
             raise IOError("Couldn't read {} field from gdf file header".format(arg))
     if "attributes" not in metadata:

--- a/harmonica/tests/test_icgem.py
+++ b/harmonica/tests/test_icgem.py
@@ -22,16 +22,15 @@ def test_load_icgem_gdf():
     shape = (nlat, nlon)
     lat = np.linspace(s, n, nlat, dtype="float64")
     lon = np.linspace(w, e, nlon, dtype="float64")
-    lon, lat = np.meshgrid(lon, lat)
     true_data = np.array([np.arange(nlon)] * nlat, dtype="float64")
     height = 1100 * np.ones(shape)
 
-    assert icgem_grd.dims["northing"] == nlat
-    assert icgem_grd.dims["easting"] == nlon
-    npt.assert_equal(icgem_grd.lon.values, lon)
-    npt.assert_equal(icgem_grd.lat.values, lat)
+    assert icgem_grd.dims["latitude"] == nlat
+    assert icgem_grd.dims["longitude"] == nlon
+    npt.assert_equal(icgem_grd.longitude.values, lon)
+    npt.assert_equal(icgem_grd.latitude.values, lat)
     npt.assert_allclose(true_data, icgem_grd.sample_data.values)
-    npt.assert_allclose(height, icgem_grd.height.values)
+    npt.assert_allclose(height, icgem_grd.height_over_ell.values)
 
 
 def test_load_icgem_gdf_with_height():
@@ -43,14 +42,14 @@ def test_load_icgem_gdf_with_height():
     nlat, nlon = 7, 8
     lat = np.linspace(s, n, nlat, dtype="float64")
     lon = np.linspace(w, e, nlon, dtype="float64")
-    lon, lat = np.meshgrid(lon, lat)
     true_data = np.array([np.arange(nlon)] * nlat, dtype="float64")
-    height = lon + lat
+    glon, glat = np.meshgrid(lon, lat)
+    height = glon + glat
 
-    assert icgem_grd.dims["northing"] == nlat
-    assert icgem_grd.dims["easting"] == nlon
-    npt.assert_equal(icgem_grd.lon.values, lon)
-    npt.assert_equal(icgem_grd.lat.values, lat)
+    assert icgem_grd.dims["latitude"] == nlat
+    assert icgem_grd.dims["longitude"] == nlon
+    npt.assert_equal(icgem_grd.longitude.values, lon)
+    npt.assert_equal(icgem_grd.latitude.values, lat)
     npt.assert_allclose(true_data, icgem_grd.sample_data.values)
     npt.assert_allclose(height, icgem_grd.h_over_geoid.values)
 
@@ -65,14 +64,13 @@ def test_load_icgem_gdf_usecols():
     shape = (nlat, nlon)
     lat = np.linspace(s, n, nlat, dtype="float64")
     lon = np.linspace(w, e, nlon, dtype="float64")
-    lon, lat = np.meshgrid(lon, lat)
     height = 1100 * np.ones(shape)
 
-    assert icgem_grd.dims["northing"] == nlat
-    assert icgem_grd.dims["easting"] == nlon
-    npt.assert_equal(icgem_grd.lon.values, lon)
-    npt.assert_equal(icgem_grd.lat.values, lat)
-    npt.assert_allclose(height, icgem_grd.height.values)
+    assert icgem_grd.dims["latitude"] == nlat
+    assert icgem_grd.dims["longitude"] == nlon
+    npt.assert_equal(icgem_grd.longitude.values, lon)
+    npt.assert_equal(icgem_grd.latitude.values, lat)
+    npt.assert_allclose(height, icgem_grd.height_over_ell.values)
     assert len(icgem_grd.data_vars) == 1
 
 


### PR DESCRIPTION
The latitude and longitude were being read as 2D arrays and referenced
to "northing" and "easting" helper coordinates. Since this grid is not
projected, there is no need for that. 

Rename coordinates to "latitude" and "longitude" instead of "lon" "lat".
Refactor the function to be a bit smaller when creating the array.
Mainly, prepare all arguments before instantiating the Dataset instead
of assigning the values afterward.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
