### PR TITLE
Add first_eccentricity to RefereceEllipsoid

### DIFF
--- a/harmonica/ellipsoid.py
+++ b/harmonica/ellipsoid.py
@@ -95,6 +95,8 @@ class ReferenceEllipsoid:
     0.0033528
     >>> print("{:.13e}".format(wgs84.linear_eccentricity))
     5.2185400842339e+05
+    >>> print("{:.13e}".format(wgs84.first_eccentricity))
+    8.1819190842621e-02
     >>> print("{:.13e}".format(wgs84.second_eccentricity))
     8.2094437949696e-02
     >>> print("{:.14f}".format(wgs84.emm))

--- a/harmonica/ellipsoid.py
+++ b/harmonica/ellipsoid.py
@@ -129,6 +129,11 @@ class ReferenceEllipsoid:
         return math.sqrt(self.semimajor_axis ** 2 - self.semiminor_axis ** 2)
 
     @property
+    def first_eccentricity(self):
+        "The first eccentricity [adimensional]"
+        return self.linear_eccentricity / self.semimajor_axis
+
+    @property
     def second_eccentricity(self):
         "The second eccentricity [adimensional]"
         return self.linear_eccentricity / self.semiminor_axis


### PR DESCRIPTION
Add `first_eccentricity` property to `ReferenceEllipsoid`.

Fixes #26

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
