### PR TITLE
Add geocentric to geodetic coordinates conversion

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -42,6 +42,7 @@ Coordinates Conversions
    :toctree: generated/
 
     geodetic_to_spherical
+    spherical_to_geodetic
 
 Input and Output
 ----------------

--- a/harmonica/__init__.py
+++ b/harmonica/__init__.py
@@ -11,7 +11,7 @@ from .ellipsoid import (
 from .io import load_icgem_gdf
 from .isostasy import isostasy_airy
 from .gravity_corrections import normal_gravity, bouguer_correction
-from .coordinates import geodetic_to_spherical
+from .coordinates import geodetic_to_spherical, spherical_to_geodetic
 
 
 # Get the version number through versioneer

--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -44,3 +44,47 @@ def geodetic_to_spherical(latitude, height):
     radius = np.sqrt(xy_projection ** 2 + z_cartesian ** 2)
     geocentric_latitude = 180 / np.pi * np.arcsin(z_cartesian / radius)
     return geocentric_latitude, radius
+
+
+def spherical_to_geodetic(geocentric_latitude, radius):
+    """
+    Convert from geocentric spherical to geodetic coordinates.
+
+    The geodetic datum is defined by the default :class:`harmonica.ReferenceEllipsoid`
+    set by the :func:`harmonica.set_ellipsoid` function.
+    The coordinates are converted following [Vermeille2002]_.
+
+    Parameters
+    ----------
+    geocentric_latitude : float or array
+        The latitude coordinate in the geocentric spherical reference system
+        (in degrees).
+    radius : float or array
+        The radial coordinate in the geocentric spherical reference system (in meters).
+
+    Returns
+    -------
+    latitude : float or array
+        The geodetic latitude (in degrees).
+    height : float or array
+        The ellipsoidal (geometric or geodetic) height (in meters).
+    """
+    ellipsoid = get_ellipsoid()
+    # Convert latitude to radians
+    geocentric_latitude_rad = np.radians(geocentric_latitude)
+    Z = radius * np.sin(geocentric_latitude_rad)
+    p = radius ** 2 * np.cos(geocentric_latitude_rad) ** 2 / \
+        ellipsoid.semimajor_axis ** 2
+    q = (1 - ellipsoid.first_eccentricity ** 2) / ellipsoid.semimajor_axis ** 2 * Z ** 2
+    r = (p + q - ellipsoid.first_eccentricity ** 4) / 6
+    s = ellipsoid.first_eccentricity ** 4 * p * q / 4 / r ** 3
+    t = np.cbrt(1 + s + np.sqrt(2 * s + s ** 2))
+    u = r * (1 + t + 1 / t)
+    v = np.sqrt(u ** 2 + q * ellipsoid.first_eccentricity ** 4)
+    w = ellipsoid.first_eccentricity ** 2 * (u + v - q) / 2 / v
+    k = np.sqrt(u + v + w ** 2) - w
+    D = k * radius * np.cos(geocentric_latitude_rad) / \
+        (k + ellipsoid.first_eccentricity ** 2)
+    latitude = np.degrees(2 * np.arctan(Z / (D + np.sqrt(D ** 2 + Z ** 2))))
+    height = (k + ellipsoid.first_eccentricity ** 2 - 1) / k * np.sqrt(D ** 2 + Z ** 2)
+    return latitude, height

--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -74,8 +74,11 @@ def spherical_to_geodetic(geocentric_latitude, radius):
     latitude = np.degrees(
         2 * np.arctan(big_z / (big_d + np.sqrt(big_d ** 2 + big_z ** 2)))
     )
-    height = (k + ellipsoid.first_eccentricity ** 2 - 1) / k \
+    height = (
+        (k + ellipsoid.first_eccentricity ** 2 - 1)
+        / k
         * np.sqrt(big_d ** 2 + big_z ** 2)
+    )
     return latitude, height
 
 
@@ -85,10 +88,16 @@ def _spherical_to_geodetic_parameters(geocentric_latitude, radius):
     # Convert latitude to radians
     geocentric_latitude_rad = np.radians(geocentric_latitude)
     big_z = radius * np.sin(geocentric_latitude_rad)
-    p_0 = radius ** 2 * np.cos(geocentric_latitude_rad) ** 2 / \
-        ellipsoid.semimajor_axis ** 2
-    q_0 = (1 - ellipsoid.first_eccentricity ** 2) / ellipsoid.semimajor_axis ** 2 \
+    p_0 = (
+        radius ** 2
+        * np.cos(geocentric_latitude_rad) ** 2
+        / ellipsoid.semimajor_axis ** 2
+    )
+    q_0 = (
+        (1 - ellipsoid.first_eccentricity ** 2)
+        / ellipsoid.semimajor_axis ** 2
         * big_z ** 2
+    )
     r_0 = (p_0 + q_0 - ellipsoid.first_eccentricity ** 4) / 6
     s_0 = ellipsoid.first_eccentricity ** 4 * p_0 * q_0 / 4 / r_0 ** 3
     t_0 = np.cbrt(1 + s_0 + np.sqrt(2 * s_0 + s_0 ** 2))
@@ -96,6 +105,10 @@ def _spherical_to_geodetic_parameters(geocentric_latitude, radius):
     v_0 = np.sqrt(u_0 ** 2 + q_0 * ellipsoid.first_eccentricity ** 4)
     w_0 = ellipsoid.first_eccentricity ** 2 * (u_0 + v_0 - q_0) / 2 / v_0
     k = np.sqrt(u_0 + v_0 + w_0 ** 2) - w_0
-    big_d = k * radius * np.cos(geocentric_latitude_rad) / \
-        (k + ellipsoid.first_eccentricity ** 2)
+    big_d = (
+        k
+        * radius
+        * np.cos(geocentric_latitude_rad)
+        / (k + ellipsoid.first_eccentricity ** 2)
+    )
     return k, big_d, big_z

--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -28,6 +28,10 @@ def geodetic_to_spherical(latitude, height):
         (in degrees).
     radius : float or array
         The radial coordinate in the geocentric spherical reference system (in meters).
+
+    See also
+    --------
+    spherical_to_geodetic : Convert from geocentric spherical to geodetic coordinates.
     """
     ellipsoid = get_ellipsoid()
     # Convert latitude to radians
@@ -68,6 +72,10 @@ def spherical_to_geodetic(geocentric_latitude, radius):
         The geodetic latitude (in degrees).
     height : float or array
         The ellipsoidal (geometric or geodetic) height (in meters).
+
+    See also
+    --------
+    geodetic_to_spherical : Convert from geodetic to geocentric spherical coordinates.
     """
     ellipsoid = get_ellipsoid()
     k, big_d, big_z = _spherical_to_geodetic_parameters(geocentric_latitude, radius)

--- a/harmonica/tests/test_coordinates.py
+++ b/harmonica/tests/test_coordinates.py
@@ -113,8 +113,7 @@ def test_identity():
         with set_ellipsoid(ellipsoid_name):
             geocentric_latitude, radius = geodetic_to_spherical(latitude, height)
             converted_latitude, converted_height = spherical_to_geodetic(
-                geocentric_latitude,
-                radius
+                geocentric_latitude, radius
             )
             npt.assert_allclose(latitude, converted_latitude, rtol=rtol)
             npt.assert_allclose(height, converted_height, rtol=rtol)

--- a/harmonica/tests/test_coordinates.py
+++ b/harmonica/tests/test_coordinates.py
@@ -4,7 +4,7 @@ Test coordinates conversions.
 import numpy as np
 import numpy.testing as npt
 
-from ..coordinates import geodetic_to_spherical
+from ..coordinates import geodetic_to_spherical, spherical_to_geodetic
 from ..ellipsoid import (
     KNOWN_ELLIPSOIDS,
     set_ellipsoid,
@@ -52,5 +52,52 @@ def test_geodetic_to_spherical_on_poles():
         with set_ellipsoid(ellipsoid_name):
             ellipsoid = get_ellipsoid()
             geocentric_latitude, radius = geodetic_to_spherical(latitude, height)
+            npt.assert_allclose(geocentric_latitude, latitude, rtol=rtol)
+            npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
+
+
+def test_spherical_to_geodetic_with_spherical_ellipsoid():
+    "Test spherical to geodetic coordinates conversion if ellipsoid is a sphere."
+    rtol = 1e-10
+    sphere_radius = 1.0
+    # Define a "spherical" ellipsoid with radius equal to 1m.
+    # To do so, we define a zero flattening, thus an infinite inverse flattening.
+    spherical_ellipsoid = ReferenceEllipsoid(
+        "unit_sphere", sphere_radius, np.infty, 0, 0
+    )
+    with set_ellipsoid(spherical_ellipsoid):
+        geocentric_latitude = np.linspace(-90, 90, 5)
+        radius = np.linspace(0.8, 1.2, 5)
+        latitude, height = spherical_to_geodetic(geocentric_latitude, radius)
+        npt.assert_allclose(geocentric_latitude, latitude, rtol=rtol)
+        npt.assert_allclose(radius, sphere_radius + height, rtol=rtol)
+
+
+def test_spherical_to_geodetic_on_equator():
+    "Test spherical to geodetic coordinates conversion on equator."
+    rtol = 1e-10
+    size = 5
+    geocentric_latitude = np.zeros(size)
+    for ellipsoid_name in KNOWN_ELLIPSOIDS:
+        with set_ellipsoid(ellipsoid_name):
+            ellipsoid = get_ellipsoid()
+            radius = np.linspace(-1e4, 1e4, size) + ellipsoid.semimajor_axis
+            latitude, height = spherical_to_geodetic(geocentric_latitude, radius)
+            npt.assert_allclose(geocentric_latitude, latitude, rtol=rtol)
+            npt.assert_allclose(radius, height + ellipsoid.semimajor_axis, rtol=rtol)
+
+
+def test_spherical_to_geodetic_on_poles():
+    "Test spherical to geodetic coordinates conversion on poles."
+    rtol = 1e-10
+    size = 5
+    geocentric_latitude = np.array([90.0] * size + [-90.0] * size)
+    for ellipsoid_name in KNOWN_ELLIPSOIDS:
+        with set_ellipsoid(ellipsoid_name):
+            ellipsoid = get_ellipsoid()
+            radius = np.hstack(
+                [np.linspace(-1e4, 1e4, size) + ellipsoid.semiminor_axis] * 2
+            )
+            latitude, height = spherical_to_geodetic(geocentric_latitude, radius)
             npt.assert_allclose(geocentric_latitude, latitude, rtol=rtol)
             npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)

--- a/harmonica/tests/test_coordinates.py
+++ b/harmonica/tests/test_coordinates.py
@@ -101,3 +101,20 @@ def test_spherical_to_geodetic_on_poles():
             latitude, height = spherical_to_geodetic(geocentric_latitude, radius)
             npt.assert_allclose(geocentric_latitude, latitude, rtol=rtol)
             npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
+
+
+def test_geodetic_to_spherical_and_spherical_to_geodetic():
+    "Test if geodetic_to_spherical and spherical_to_geodetic is the identity operator"
+    rtol = 1e-10
+    latitude = np.linspace(-90, 90, 19)
+    height = np.linspace(-1e4, 1e4, 8)
+    latitude, height = np.meshgrid(latitude, height)
+    for ellipsoid_name in KNOWN_ELLIPSOIDS:
+        with set_ellipsoid(ellipsoid_name):
+            geocentric_latitude, radius = geodetic_to_spherical(latitude, height)
+            converted_latitude, converted_height = spherical_to_geodetic(
+                geocentric_latitude,
+                radius
+            )
+            npt.assert_allclose(latitude, converted_latitude, rtol=rtol)
+            npt.assert_allclose(height, converted_height, rtol=rtol)

--- a/harmonica/tests/test_coordinates.py
+++ b/harmonica/tests/test_coordinates.py
@@ -103,7 +103,7 @@ def test_spherical_to_geodetic_on_poles():
             npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
 
 
-def test_geodetic_to_spherical_and_spherical_to_geodetic():
+def test_identity():
     "Test if geodetic_to_spherical and spherical_to_geodetic is the identity operator"
     rtol = 1e-10
     latitude = np.linspace(-90, 90, 19)


### PR DESCRIPTION
Convert geocentric spherical coordinates to geocentric coordinates (defined by the
`ReferenceEllipsoid`). Only geodetic `geocentric_latitude` and `radius` are converted to
`latitude` and `height`, geocentric and geodetic longitudes are equal.
Also add links on `spherical_to_geodetic` and `geodetic_to_spherical` to each other on
theirs docstring.

Add tests for new function: 
1. Test with a "spherical" ellipsoid (in such case the geodetic and gecentric
   coordinates are the same).
2. Test with real ellipsoids on equator and poles (on those points geodetic and
   geocentric latitudes are must be equal).
3. Perform an identity test, i.e. applying `geodetic_to_spherical` and then
   `spherical_to_geodetic` must be equal to the identity operator, obtaining the
   original set of `latitude` and `height`.

Fixes #40 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.