### PR TITLE
Improve radians to degrees conversion

### DIFF
--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -42,5 +42,5 @@ def geodetic_to_spherical(latitude, height):
         height + (1 - ellipsoid.first_eccentricity ** 2) * prime_vertical_radius
     ) * np.sin(latitude_rad)
     radius = np.sqrt(xy_projection ** 2 + z_cartesian ** 2)
-    geocentric_latitude = 180 / np.pi * np.arcsin(z_cartesian / radius)
+    geocentric_latitude = np.degrees(np.arcsin(z_cartesian / radius))
     return geocentric_latitude, radius


### PR DESCRIPTION
Replace the bad styling `180 / numpy.pi` for the `numpy.degrees()` function for converting
radians to degrees.

Fixes #42 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
