### PR TITLE
Assign authorship to "The Harmonica Developers"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
-# Project Contributors
+# Project Authors
 
-The following people have made contributions to the project (in alphabetical order):
+The following people have made contributions to the project (in alphabetical order by
+last name) and are considered "The Harmonica Developers":
 
-* [Santiago Soler](https://santis19.github.io/)
-* [Leonardo Uieda](http://www.leouieda.com/)
+* [Santiago Soler](https://github.com/santisoler)
+* [Leonardo Uieda](https://github.com/leouieda)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Leonardo Uieda
+Copyright (c) 2018-2019 The Harmonica Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -9,7 +9,7 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-* Neither the name of Leonardo Uieda nor the names of any contributors
+* Neither the name of The Harmonica Developers nor the names of any contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,7 +78,7 @@ master_doc = 'index'
 # General information about the project
 year = datetime.date.today().year
 project = 'Harmonica'
-copyright = '2018-{}, Leonardo Uieda'.format(year)
+copyright = '2018-{}, The Harmonica Developers'.format(year)
 if len(full_version.split('+')) > 1 or full_version == 'unknown':
     version = 'dev'
 else:

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ import versioneer
 
 NAME = "harmonica"
 FULLNAME = "Harmonica"
-AUTHOR = "Leonardo Uieda"
+AUTHOR = "The Harmonica Developers"
 AUTHOR_EMAIL = "leouieda@gmail.com"
-MAINTAINER = AUTHOR
+MAINTAINER = "Leonardo Uieda"
 MAINTAINER_EMAIL = AUTHOR_EMAIL
 LICENSE = "BSD License"
 URL = "https://github.com/fatiando/harmonica"


### PR DESCRIPTION
Replaces my name with "The Harmonica Developers" in authorship claims and
copyright notices. Include a definition of what that term means in the
AUTHORS.md file.
Left my name and email as maintainer on the setup.py because we don't
have a project email yet.