### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,6 @@ branches:
 
 environment:
     matrix:
-        - MINICONDA: C:\Miniconda35-x64
-          PYTHON: 3.5
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
         - MINICONDA: C:\Miniconda37-x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,6 @@ matrix:
               - BUILD_DOCS=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
-        - name: "Linux - Python 3.5"
-          os: linux
-          env:
-              - PYTHON=3.5
-              - TEST=true
-              - BUILD_DOCS=true
         - name: "Mac - Python 3.7"
           os: osx
           env:

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.5 or greater**.
+You'll need **Python 3.6 or greater**.
 
 We recommend using the
 `Anaconda Python distribution <https://www.anaconda.com/download>`__

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ CLASSIFIERS = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: {}".format(LICENSE),
@@ -42,7 +41,7 @@ PACKAGE_DATA = {
     "harmonica.tests": ["data/*", "baseline/*"],
 }
 INSTALL_REQUIRES = ["numpy", "scipy", "pandas", "pooch", "attrs", "xarray", "verde"]
-PYTHON_REQUIRES = ">=3.5"
+PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
Change support for Python 3.6 or higher because conda-forge is no longer
building 3.5 packages.

Fixes #51 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
