### PR TITLE
Fix: CI scripts 1.1.1 instead of master in Azure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,15 +21,13 @@ init:
     # The files with the listed requirements to be installed by setup-miniconda.bat
     - set CONDA_REQUIREMENTS=requirements.txt
     - set CONDA_REQUIREMENTS_DEV=requirements-dev.txt
-    # Cartopy, scipy, and proj aren't on conda-forge for some reason.
-    - set CONDA_EXTRA_CHANNEL=defaults
 
 install:
     # Copy sample data to the verde data dir to avoid downloading all the time
     - ps: mkdir -p ~\.harmonica\data\master
     - ps: cp data\* ~\.harmonica\data\master
     # Get the Fatiando CI scripts
-    - cmd: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+    - cmd: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Setup miniconda and install the requirements into a new environment
     - cmd: continuous-integration\appveyor\setup-miniconda.bat
     # Activate the new environment

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - bash: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -93,7 +93,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - bash: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -161,8 +161,6 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    # Cartopy, scipy, and proj aren't on conda-forge for some reason.
-    CONDA_EXTRA_CHANNEL: defaults
 
   strategy:
     matrix:
@@ -179,7 +177,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - script: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - script: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
   - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
     displayName: Add conda to PATH
 
-  # Get the Fatiando CI scripts (replace "master" with the version you want to use)
+  # Get the Fatiando CI scripts
   - bash: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
@@ -92,8 +92,8 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
-  # Get the Fatiando CI scripts (replace "master" with the version you want to use)
-  - bash: git clone --branch=master --depth=1 https://github.com/fatiando/continuous-integration.git
+  # Get the Fatiando CI scripts
+  - bash: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -178,8 +178,8 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
 
-  # Get the Fatiando CI scripts (replace "master" with the version you want to use)
-  - script: git clone --branch=master --depth=1 https://github.com/fatiando/continuous-integration.git
+  # Get the Fatiando CI scripts
+  - script: git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
     - mkdir -p $HOME/.harmonica/data/master
     - cp -r data/* $HOME/.harmonica/data/master
     # Get the Fatiando CI scripts
-    - git clone --branch=1.1.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+    - git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh


### PR DESCRIPTION
Was using the master branch by mistake in Azure Pipelines.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
