### PR TITLE
Forward modelling for tesseroids

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -22,6 +22,7 @@ Dependencies
 * `numpy <http://www.numpy.org/>`__
 * `scipy <https://docs.scipy.org/doc/scipy/reference/>`__
 * `pandas <http://pandas.pydata.org/>`__
+* `numba <https://numba.pydata.org/>`__
 * `xarray <https://xarray.pydata.org/>`__
 * `attrs <https://www.attrs.org/>`__
 * `pooch <http://www.fatiando.org/pooch/>`__

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - numpy
     - scipy
     - pandas
+    - numba
     - pooch
     - verde
     - attrs

--- a/harmonica/forward/__init__.py
+++ b/harmonica/forward/__init__.py
@@ -1,0 +1,3 @@
+"""
+Forward modeling functions for the gravity and magnetic fields of geometric shapes.
+"""

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -52,14 +52,7 @@ def adaptive_discretization(
 
 
 @jit(nopython=True)
-def _split_tesseroid(
-    tesseroid,
-    split_lon,
-    split_lat,
-    split_radial,
-    stack,
-    stack_top,
-):
+def _split_tesseroid(tesseroid, split_lon, split_lat, split_radial, stack, stack_top):
     """
     Split tesseroid along each dimension
     """

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -108,19 +108,17 @@ def _distance_tesseroid_point(coordinates, tesseroid):
     """
     longitude, latitude, radius = coordinates[:]
     longitude, latitude = np.radians(longitude), np.radians(latitude)
-    w, e, s, n, bottom, top = tesseroid[:]
     # Get center of the tesseroid
-    longitude_p = (e + w) / 2
-    latitude_p = (n + s) / 2
-    radius_p = (top + bottom) / 2
+    longitude_p = (tesseroid[0] + tesseroid[1]) / 2
+    latitude_p = (tesseroid[2] + tesseroid[3]) / 2
+    radius_p = (tesseroid[4] + tesseroid[5]) / 2
     # Convert angles to radians
     longitude_p, latitude_p = np.radians(longitude_p), np.radians(latitude_p)
     cosphi_p = np.cos(latitude_p)
     sinphi_p = np.sin(latitude_p)
-    radius_p_sq = radius_p ** 2
     cosphi = np.cos(latitude)
     sinphi = np.sin(latitude)
     coslambda = np.cos(longitude_p - longitude)
     cospsi = sinphi_p * sinphi + cosphi_p * cosphi * coslambda
-    distance = np.sqrt(radius ** 2 + radius_p_sq - 2 * radius * radius_p * cospsi)
+    distance = np.sqrt(radius ** 2 + radius_p ** 2 - 2 * radius * radius_p * cospsi)
     return distance

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -87,7 +87,6 @@ def _split_tesseroid(tesseroid, n_lon, n_lat, n_rad, stack, stack_top):
     if stack_top + n_lon * n_lat * n_rad > stack.shape[0]:
         raise OverflowError("Tesseroid stack overflow.")
     # Compute differential distance
-    # These lines may give errors while working near the 0 - 360 boundary
     d_lon = (e - w) / n_lon
     d_lat = (n - s) / n_lat
     d_rad = (top - bottom) / n_rad

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -18,7 +18,7 @@ def adaptive_discretization(
     radial_discretization=False,
 ):
     """
-    Two dimensional adaptive discretization
+    Three or two dimensional adaptive discretization
     """
     # Create list of small tesseroids
     small_tesseroids = []

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -20,7 +20,7 @@ def adaptive_discretization(
     small_tesseroids = []
     # Create stack of tesseroids
     stack = np.zeros((stack_size, 6))
-    stack[0, :] = np.array([tesseroid])
+    stack[0, :] = tesseroid
     stack_top = 0
     while stack_top >= 0:
         # Pop the first tesseroid from the stack
@@ -33,6 +33,7 @@ def adaptive_discretization(
         # Check inequality
         split_lon = bool(distance / L_lon < distance_size_ratio)
         split_lat = bool(distance / L_lat < distance_size_ratio)
+        # Apply discretization
         if split_lon or split_lat:
             stack_top = _split_tesseroid(
                 tesseroid, split_lon, split_lat, stack, stack_top

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -64,7 +64,7 @@ def _split_tesseroid(
     stack_size,
 ):
     """
-    Split tesseroid along horizontal dimensions
+    Split tesseroid along each dimension
     """
     w, e, s, n, bottom, top = tesseroid[:]
     n_lon, n_lat = 1, 1

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -54,7 +54,15 @@ def adaptive_discretization(
 
 
 @jit(nopython=True)
-def _split_tesseroid(tesseroid, split_lon, split_lat, split_radial, stack, stack_top):
+def _split_tesseroid(
+    tesseroid,
+    split_lon,
+    split_lat,
+    split_radial,
+    stack,
+    stack_top,
+    stack_size,
+):
     """
     Split tesseroid along horizontal dimensions
     """
@@ -66,6 +74,8 @@ def _split_tesseroid(tesseroid, split_lon, split_lat, split_radial, stack, stack
         n_lat = 2
     if split_radial:
         n_radial = 2
+    if stack_top + n_lon * n_lat * n_radial > stack_size:
+        raise OverflowError("Tesseroid stack overflow.")
     # Compute differential distance
     # These lines may give errors while working near the 0 - 360 boundary
     d_lon = (e - w) / n_lon

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -31,13 +31,13 @@ def adaptive_discretization(
         tesseroid = [stack[stack_top, i] for i in range(6)]
         stack_top -= 1
         # Get its dimensions
-        L_lon, L_lat, L_r = _tesseroid_dimensions(tesseroid)
+        l_lon, l_lat, l_rad = _tesseroid_dimensions(tesseroid)
         # Get distance between computation point and center of tesseroid
         distance = _distance_tesseroid_point(coordinates, tesseroid)
         # Check inequality
-        split_lon = bool(distance / L_lon < distance_size_ratio)
-        split_lat = bool(distance / L_lat < distance_size_ratio)
-        split_radial = bool(distance / L_r < distance_size_ratio)
+        split_lon = bool(distance / l_lon < distance_size_ratio)
+        split_lat = bool(distance / l_lat < distance_size_ratio)
+        split_radial = bool(distance / l_rad < distance_size_ratio)
         # Choose 2D or 3D adaptive discretization
         if not radial_discretization:
             split_radial = False
@@ -93,12 +93,12 @@ def _tesseroid_dimensions(tesseroid):
     w, e, s, n, bottom, top = tesseroid[:]
     w, e, s, n = np.radians(w), np.radians(e), np.radians(s), np.radians(n)
     latitude_center = (n + s) / 2
-    L_lat = top * np.arccos(np.sin(n) * np.sin(s) + np.cos(n) * np.cos(s))
-    L_lon = top * np.arccos(
+    l_lat = top * np.arccos(np.sin(n) * np.sin(s) + np.cos(n) * np.cos(s))
+    l_lon = top * np.arccos(
         np.sin(latitude_center) ** 2 + np.cos(latitude_center) ** 2 * np.cos(e - w)
     )
-    L_r = top - bottom
-    return L_lon, L_lat, L_r
+    l_rad = top - bottom
+    return l_lon, l_lat, l_rad
 
 
 @jit(nopython=True)

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -1,0 +1,95 @@
+"""
+Forward modelling for tesseroids
+"""
+import numpy as np
+from numba import jit
+
+from ..constants import GRAVITATIONAL_CONST
+
+
+def adaptive_discretization(coordinates, tesseroid, distance_size_ratio):
+    """
+    Two dimensional adaptive discretization
+    """
+    # Create list of small tesseroids
+    small_tesseroids = []
+    # Create stack of tesseroids
+    stack = [tesseroid]
+    while stack:
+        # Pop the first tesseroid from the stack
+        tesseroid = stack.pop()
+        # Get its dimensions
+        L_lon, L_lat = _tesseroid_horizontal_dimensions(tesseroid)
+        # Get distance between computation point and center of tesseroid
+        distance = _distance_tesseroid_point(coordinates, tesseroid)
+        # Check inequality
+        split_lon = bool(distance / L_lon < distance_size_ratio)
+        split_lat = bool(distance / L_lat < distance_size_ratio)
+        if split_lon or split_lat:
+            _split_tesseroid(tesseroid, split_lon, split_lat, stack)
+        else:
+            small_tesseroids.append(tesseroid)
+    return np.array(small_tesseroids)
+
+
+def _split_tesseroid(tesseroid, split_lon, split_lat, stack):
+    """
+    Split tesseroid along horizontal dimensions
+    """
+    w, e, s, n, bottom, top = tesseroid[:]
+    n_lon, n_lat = 1, 1
+    if split_lon:
+        n_lon = 2
+    if split_lat:
+        n_lat = 2
+    d_lon = (e - w) / n_lon
+    d_lat = (n - s) / n_lat
+    for i in range(n_lon):
+        for j in range(n_lat):
+            stack.append(
+                [
+                    w + d_lon * i,
+                    w + d_lon * (i + 1),
+                    s + d_lat * j,
+                    s + d_lat * (j + 1),
+                    bottom,
+                    top,
+                ]
+            )
+
+
+def _tesseroid_horizontal_dimensions(tesseroid):
+    """
+    Calculate the horizontal dimensions of the tesseroid.
+    """
+    w, e, s, n = np.radians(np.array(tesseroid[:4]))
+    bottom, top = tesseroid[-2:]
+    latitude_center = (n + s) / 2
+    L_lat = top * np.arccos(np.sin(n) * np.sin(s) + np.cos(n) * np.cos(s))
+    L_lon = top * np.arccos(
+        np.sin(latitude_center) ** 2 + np.cos(latitude_center) ** 2 * np.cos(e - w)
+    )
+    return L_lon, L_lat
+
+
+def _distance_tesseroid_point(coordinates, tesseroid):
+    """
+    Calculate the distance between a computation point and the center of a tesseroid.
+    """
+    longitude, latitude, radius = coordinates[:]
+    w, e, s, n, bottom, top = tesseroid[:]
+    # Get center of the tesseroid
+    longitude_p = (e + w) / 2
+    latitude_p = (n + s) / 2
+    radius_p = (top + bottom) / 2
+    # Convert angles to radians
+    longitude_p, latitude_p = np.radians(longitude_p), np.radians(latitude_p)
+    cosphi_p = np.cos(latitude_p)
+    sinphi_p = np.sin(latitude_p)
+    radius_p_sq = radius_p ** 2
+    cosphi = np.cos(latitude)
+    sinphi = np.sin(latitude)
+    coslambda = np.cos(longitude_p - longitude)
+    cospsi = sinphi_p * sinphi + cosphi_p * cosphi * coslambda
+    distance = np.sqrt(radius ** 2 + radius_p_sq - 2 * radius * radius_p * cospsi)
+    return distance

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -59,19 +59,19 @@ def _split_tesseroid(
     split_radial,
     stack,
     stack_top,
-    stack_size,
 ):
     """
     Split tesseroid along each dimension
     """
     w, e, s, n, bottom, top = tesseroid[:]
-    n_lon, n_lat = 1, 1
+    n_lon, n_lat, n_radial = 1, 1, 1
     if split_lon:
         n_lon = 2
     if split_lat:
         n_lat = 2
     if split_radial:
         n_radial = 2
+    stack_size = stack.shape[0]
     if stack_top + n_lon * n_lat * n_radial > stack_size:
         raise OverflowError("Tesseroid stack overflow.")
     # Compute differential distance

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -114,6 +114,7 @@ def _distance_tesseroid_point(coordinates, tesseroid):
     Calculate the distance between a computation point and the center of a tesseroid.
     """
     longitude, latitude, radius = coordinates[:]
+    longitude, latitude = np.radians(longitude), np.radians(latitude)
     w, e, s, n, bottom, top = tesseroid[:]
     # Get center of the tesseroid
     longitude_p = (e + w) / 2

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.testing as npt
 from pytest import raises
 
-from ..tesseroid import _distance_tesseroid_point
+from ..tesseroid import _distance_tesseroid_point, _tesseroid_dimensions
 
 
 def test_distance_tesseroid_point():
@@ -37,3 +37,13 @@ def test_distance_tesseroid_point():
     point = [longitude_p, latitude, radius_p]
     distance = 2 * radius_p * np.sin(0.5 * np.radians(abs(latitude - latitude_p)))
     npt.assert_allclose(_distance_tesseroid_point(point, tesseroid), distance)
+
+
+def test_tesseroid_dimensions():
+    "Test calculation of tesseroid dimensions"
+    # Tesseroid on equator
+    w, e, s, n, bottom, top = -1.0, 1.0, -1.0, 1.0, 0.5, 1.5
+    tesseroid = [w, e, s, n, bottom, top]
+    L_lon, L_lat = top * np.radians(abs(e - w)), top * np.radians(abs(n - s))
+    L_r = top - bottom
+    npt.assert_allclose((L_lon, L_lat, L_r), _tesseroid_dimensions(tesseroid))

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -94,3 +94,11 @@ def test_adaptive_discretization_on_D_ratio():
             number_of_splits.append(smaller_tesseroids.shape[0])
         for i in range(1, len(number_of_splits)):
             assert number_of_splits[i - 1] <= number_of_splits[i]
+
+
+def test_stack_overflow():
+    "Test if adaptive discretization raises OverflowError on stack overflow"
+    tesseroid = [-10.0, 10.0, -10.0, 10.0, 0.5, 1.0]
+    coordinates = [0.0, 0.0, 1.0]
+    with raises(OverflowError):
+        adaptive_discretization(coordinates, tesseroid, 10.0, stack_size=2)

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -65,12 +65,7 @@ def test_split_tesseroid_only_longitude():
     stack = np.zeros((8, 6))
     stack_top = -1
     stack_top = _split_tesseroid(
-        tesseroid,
-        split_lon=True,
-        split_lat=False,
-        split_radial=False,
-        stack=stack,
-        stack_top=stack_top,
+        tesseroid, n_lon=2, n_lat=1, n_rad=1, stack=stack, stack_top=stack_top
     )
     splitted = np.array([tess for tess in stack if not np.all(tess == 0)])
     assert splitted.shape[0] == 2
@@ -96,12 +91,7 @@ def test_split_tesseroid_only_latitude():
     stack = np.zeros((8, 6))
     stack_top = -1
     stack_top = _split_tesseroid(
-        tesseroid,
-        split_lon=False,
-        split_lat=True,
-        split_radial=False,
-        stack=stack,
-        stack_top=stack_top,
+        tesseroid, n_lon=1, n_lat=2, n_rad=1, stack=stack, stack_top=stack_top
     )
     splitted = np.array([tess for tess in stack if not np.all(tess == 0)])
     assert splitted.shape[0] == 2
@@ -127,12 +117,7 @@ def test_split_tesseroid_only_radius():
     stack = np.zeros((8, 6))
     stack_top = -1
     stack_top = _split_tesseroid(
-        tesseroid,
-        split_lon=False,
-        split_lat=False,
-        split_radial=True,
-        stack=stack,
-        stack_top=stack_top,
+        tesseroid, n_lon=1, n_lat=1, n_rad=2, stack=stack, stack_top=stack_top
     )
     splitted = np.array([tess for tess in stack if not np.all(tess == 0)])
     assert splitted.shape[0] == 2
@@ -155,12 +140,7 @@ def test_split_tesseroid_only_horizontal():
     stack = np.zeros((8, 6))
     stack_top = -1
     stack_top = _split_tesseroid(
-        tesseroid,
-        split_lon=True,
-        split_lat=True,
-        split_radial=False,
-        stack=stack,
-        stack_top=stack_top,
+        tesseroid, n_lon=2, n_lat=2, n_rad=1, stack=stack, stack_top=stack_top
     )
     splitted = np.array([tess for tess in stack if not np.all(tess == 0)])
     assert splitted.shape[0] == 2 ** 2
@@ -179,12 +159,7 @@ def test_split_tesseroid():
     stack = np.zeros((8, 6))
     stack_top = -1
     stack_top = _split_tesseroid(
-        tesseroid,
-        split_lon=True,
-        split_lat=True,
-        split_radial=True,
-        stack=stack,
-        stack_top=stack_top,
+        tesseroid, n_lon=2, n_lat=2, n_rad=2, stack=stack, stack_top=stack_top
     )
     splitted = np.array([tess for tess in stack if not np.all(tess == 0)])
     assert splitted.shape[0] == 2 ** 3

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -56,13 +56,13 @@ def test_tesseroid_dimensions():
 def test_adaptive_discretization_on_radii():
     "Test if closer computation points increase the tesseroid discretization"
     for radial_discretization in [True, False]:
-        tesseroid = [-10.0, 10.0, -10.0, 10.0, 0.5, 1.0]
-        radii = [1.5, 2.0, 3.0, 5.0, 10.0]
+        tesseroid = [-10.0, 10.0, -10.0, 10.0, 1.0, 10.0]
+        radii = [10.5, 12.0, 13.0, 15.0, 20.0, 30.0]
         # Only if 2D adaptive discretization set point on the surface of the tesseroid
         if radial_discretization:
-            radii.insert(0, 1.01)
+            radii.insert(0, 10.1)
         else:
-            radii.insert(0, 1.0)
+            radii.insert(0, 10.0)
         number_of_splits = []
         for radius in radii:
             coordinates = [0.0, 0.0, radius]
@@ -80,8 +80,8 @@ def test_adaptive_discretization_on_radii():
 def test_adaptive_discretization_on_D_ratio():
     "Test if higher distance-size-ratio increase the tesseroid discretization"
     for radial_discretization in [True, False]:
-        tesseroid = [-10.0, 10.0, -10.0, 10.0, 0.5, 1.0]
-        coordinates = [0.0, 0.0, 1.2]
+        tesseroid = [-10.0, 10.0, -10.0, 10.0, 1.0, 10.0]
+        coordinates = [0.0, 0.0, 10.2]
         distance_size_ratii = np.linspace(1, 10, 10)
         number_of_splits = []
         for D in distance_size_ratii:

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -219,18 +219,18 @@ def test_adaptive_discretization_on_radii():
             assert number_of_splits[i - 1] >= number_of_splits[i]
 
 
-def test_adaptive_discretization_on_D_ratio():
+def test_adaptive_discretization_on_distance_size_ratio():
     "Test if higher distance-size-ratio increase the tesseroid discretization"
     for radial_discretization in [True, False]:
         tesseroid = [-10.0, 10.0, -10.0, 10.0, 1.0, 10.0]
         coordinates = [0.0, 0.0, 10.2]
         distance_size_ratii = np.linspace(1, 10, 10)
         number_of_splits = []
-        for D in distance_size_ratii:
+        for distance_size_ratio in distance_size_ratii:
             smaller_tesseroids = adaptive_discretization(
                 coordinates,
                 tesseroid,
-                distance_size_ratio=D,
+                distance_size_ratio=distance_size_ratio,
                 radial_discretization=radial_discretization,
             )
             number_of_splits.append(smaller_tesseroids.shape[0])

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -1,0 +1,39 @@
+"""
+Test forward modellig for point masses.
+"""
+import numpy as np
+import numpy.testing as npt
+from pytest import raises
+
+from ..tesseroid import _distance_tesseroid_point
+
+
+def test_distance_tesseroid_point():
+    "Test distance between tesseroid and computation point"
+    longitude_p, latitude_p, radius_p = 0.0, 0.0, 1.0
+    d_lon, d_lat, d_radius = 2.0, 2.0, 1.0
+    tesseroid = [
+        longitude_p - d_lon / 2,
+        longitude_p + d_lon / 2,
+        latitude_p - d_lat / 2,
+        latitude_p + d_lat / 2,
+        radius_p - d_radius / 2,
+        radius_p + d_radius / 2,
+    ]
+    # Computation point on the center of the tesseroid
+    point = [longitude_p, latitude_p, radius_p]
+    npt.assert_allclose(_distance_tesseroid_point(point, tesseroid), 0.0)
+    # Computation point and tesseroid center with same longitude and latitude
+    radius = radius_p + 1.0
+    point = [longitude_p, latitude_p, radius]
+    npt.assert_allclose(_distance_tesseroid_point(point, tesseroid), 1.0)
+    # Computation point and tesseroid center on equator and same radius
+    longitude = 3.0
+    point = [longitude, latitude_p, radius_p]
+    distance = 2 * radius_p * np.sin(0.5 * np.radians(abs(longitude - longitude_p)))
+    npt.assert_allclose(_distance_tesseroid_point(point, tesseroid), distance)
+    # Computation point and tesseroid center on same meridian and radius
+    latitude = 3.0
+    point = [longitude_p, latitude, radius_p]
+    distance = 2 * radius_p * np.sin(0.5 * np.radians(abs(latitude - latitude_p)))
+    npt.assert_allclose(_distance_tesseroid_point(point, tesseroid), distance)

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -53,7 +53,7 @@ def test_tesseroid_dimensions():
     npt.assert_allclose((L_lon, L_lat, L_r), _tesseroid_dimensions(tesseroid))
 
 
-def test_adaptive_discretization():
+def test_adaptive_discretization_on_radii():
     "Test if closer computation points increase the tesseroid discretization"
     for radial_discretization in [True, False]:
         tesseroid = [-10.0, 10.0, -10.0, 10.0, 0.5, 1.0]
@@ -75,3 +75,22 @@ def test_adaptive_discretization():
             number_of_splits.append(smaller_tesseroids.shape[0])
         for i in range(1, len(number_of_splits)):
             assert number_of_splits[i - 1] >= number_of_splits[i]
+
+
+def test_adaptive_discretization_on_D_ratio():
+    "Test if higher distance-size-ratio increase the tesseroid discretization"
+    for radial_discretization in [True, False]:
+        tesseroid = [-10.0, 10.0, -10.0, 10.0, 0.5, 1.0]
+        coordinates = [0.0, 0.0, 1.2]
+        distance_size_ratii = np.linspace(1, 10, 10)
+        number_of_splits = []
+        for D in distance_size_ratii:
+            smaller_tesseroids = adaptive_discretization(
+                coordinates,
+                tesseroid,
+                distance_size_ratio=D,
+                radial_discretization=radial_discretization,
+            )
+            number_of_splits.append(smaller_tesseroids.shape[0])
+        for i in range(1, len(number_of_splits)):
+            assert number_of_splits[i - 1] <= number_of_splits[i]

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -49,9 +49,9 @@ def test_tesseroid_dimensions():
     # Tesseroid on equator
     w, e, s, n, bottom, top = -1.0, 1.0, -1.0, 1.0, 0.5, 1.5
     tesseroid = [w, e, s, n, bottom, top]
-    L_lon, L_lat = top * np.radians(abs(e - w)), top * np.radians(abs(n - s))
-    L_r = top - bottom
-    npt.assert_allclose((L_lon, L_lat, L_r), _tesseroid_dimensions(tesseroid))
+    l_lon, l_lat = top * np.radians(abs(e - w)), top * np.radians(abs(n - s))
+    l_rad = top - bottom
+    npt.assert_allclose((l_lon, l_lat, l_rad), _tesseroid_dimensions(tesseroid))
 
 
 def test_split_tesseroid_only_longitude():

--- a/harmonica/forward/tests/test_tesseroid.py
+++ b/harmonica/forward/tests/test_tesseroid.py
@@ -102,3 +102,14 @@ def test_stack_overflow():
     coordinates = [0.0, 0.0, 1.0]
     with raises(OverflowError):
         adaptive_discretization(coordinates, tesseroid, 10.0, stack_size=2)
+
+
+def test_two_dimensional_adaptive_discretization():
+    "Test if the 2D adaptive discretization produces no splits on radial direction"
+    bottom, top = 1.0, 10.0
+    tesseroid = [-10.0, 10.0, -10.0, 10.0, bottom, top]
+    coordinates = [0.0, 0.0, top]
+    small_tesseroids = adaptive_discretization(coordinates, tesseroid, 10.0)
+    for tess in small_tesseroids:
+        assert tess[-2] == bottom
+        assert tess[-1] == top

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
 pandas
+numba
 pooch
 attrs
 xarray

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,16 @@ PACKAGE_DATA = {
     "harmonica.datasets": ["registry.txt"],
     "harmonica.tests": ["data/*", "baseline/*"],
 }
-INSTALL_REQUIRES = ["numpy", "scipy", "pandas", "pooch", "attrs", "xarray", "verde"]
+INSTALL_REQUIRES = [
+    "numpy",
+    "scipy",
+    "pandas",
+    "numba",
+    "pooch",
+    "attrs",
+    "xarray",
+    "verde",
+]
 PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":


### PR DESCRIPTION
Start porting the forward modelling for tesseroids.
This implementation will use Numba for fast code execution.

- [x] Choose between 2D and 3D adaptive discretization
- [ ] Variable density in depth
- [x] Arbitrary GLQ degree on each direction
- [ ] Unwrap angles to prevent errors (|e - w| <= pi)
- [ ] Raise error when computation point is inside the tesseroid
- [ ] Raise error when computation point is on the surface of the tesseroid and 3D adaptive discretization

Fixes #46 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
