### PR TITLE
Refactor coordinates conversion

### DIFF
--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -6,7 +6,7 @@ import numpy as np
 from . import get_ellipsoid
 
 
-def geodetic_to_spherical(coordinates):
+def geodetic_to_spherical(longitude, latitude, height):
     """
     Convert from geodetic to geocentric spherical coordinates.
 
@@ -16,26 +16,26 @@ def geodetic_to_spherical(coordinates):
 
     Parameters
     ----------
-    coordinates : list or array
-        List or array containing `longitude`, `latitude` and `height` coordinates on
-        a geodetic coordinate system. Both `longitude` and `latitude` must be in
-        degrees, and the ellipsoidal `height` in meters.
-
-    Returns
-    -------
-    spherical_coordinates : list
-        List containing the converted `longitude`, `latitude` and `radius` coordinates
-        on a spherical geocentric coordinate system. Both `longitude` and `latitude`
-        will be in degrees, and the `radius` in meters.
+    longitude : array
+        Longitude coordinates on geodetic coordinate system in degrees.
+    latitude : array
+        Latitude coordinates on geodetic coordinate system in degrees.
+    height : array
+        Ellipsoidal heights in meters.
 
     See also
     --------
-    spherical_to_geodetic : Convert from geocentric spherical to geodetic coordinates.
+    longitude : array
+        Longitude coordinates on geocentric spherical coordinate system in degrees.
+        The longitude coordinates are not modified during this conversion.
+    spherical_latitude : array
+        Converted latitude coordinates on geocentric spherical coordinate system in
+        degrees.
+    radius : array
+        Converted spherical radius coordinates in meters.
     """
     # Get ellipsoid
     ellipsoid = get_ellipsoid()
-    # Extract geodetic coordinates
-    longitude, latitude, height = coordinates[:3]
     # Convert latitude to radians
     latitude_rad = np.radians(latitude)
     prime_vertical_radius = ellipsoid.semimajor_axis / np.sqrt(
@@ -52,7 +52,7 @@ def geodetic_to_spherical(coordinates):
     return longitude, spherical_latitude, radius
 
 
-def spherical_to_geodetic(coordinates):
+def spherical_to_geodetic(longitude, spherical_latitude, radius):
     """
     Convert from geocentric spherical to geodetic coordinates.
 
@@ -62,17 +62,22 @@ def spherical_to_geodetic(coordinates):
 
     Parameters
     ----------
-    coordinates : list or array
-        List or array containing `longitude`, `latitude` and `radius` coordinates on
-        a spherical geocentric coordinate system. Both `longitude` and `latitude` must
-        be in degrees, and the `radius` in meters.
+    longitude : array
+        Longitude coordinates on geocentric spherical coordinate system in degrees.
+    spherical_latitude : array
+        Latitude coordinates on geocentric spherical coordinate system in degrees.
+    radius : array
+        Spherical radius coordinates in meters.
 
-    Returns
-    -------
-    spherical_coordinates : list
-        List containing the converted `longitude`, `latitude` and `height` coordinates
-        on a geodetic coordinate system. Both `longitude` and `latitude` will be in
-        degrees, and the ellipsoidal `height` in meters.
+    See also
+    --------
+    longitude : array
+        Longitude coordinates on geodetic coordinate system in degrees.
+        The longitude coordinates are not modified during this conversion.
+    spherical_latitude : array
+        Converted latitude coordinates on geodetic coordinate system in degrees.
+    height : array
+        Converted ellipsoidal height coordinates in meters.
 
     See also
     --------
@@ -80,8 +85,6 @@ def spherical_to_geodetic(coordinates):
     """
     # Get ellipsoid
     ellipsoid = get_ellipsoid()
-    # Extract geodetic coordinates
-    longitude, spherical_latitude, radius = coordinates[:3]
     k, big_d, big_z = _spherical_to_geodetic_parameters(spherical_latitude, radius)
     latitude = np.degrees(
         2 * np.arctan(big_z / (big_d + np.sqrt(big_d ** 2 + big_z ** 2)))

--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -23,8 +23,8 @@ def geodetic_to_spherical(longitude, latitude, height):
     height : array
         Ellipsoidal heights in meters.
 
-    See also
-    --------
+    Returns
+    -------
     longitude : array
         Longitude coordinates on geocentric spherical coordinate system in degrees.
         The longitude coordinates are not modified during this conversion.
@@ -33,6 +33,10 @@ def geodetic_to_spherical(longitude, latitude, height):
         degrees.
     radius : array
         Converted spherical radius coordinates in meters.
+
+    See also
+    --------
+    spherical_to_geodetic : Convert from geocentric spherical to geodetic coordinates.
     """
     # Get ellipsoid
     ellipsoid = get_ellipsoid()
@@ -69,8 +73,8 @@ def spherical_to_geodetic(longitude, spherical_latitude, radius):
     radius : array
         Spherical radius coordinates in meters.
 
-    See also
-    --------
+    Returns
+    -------
     longitude : array
         Longitude coordinates on geodetic coordinate system in degrees.
         The longitude coordinates are not modified during this conversion.

--- a/harmonica/coordinates.py
+++ b/harmonica/coordinates.py
@@ -37,6 +37,27 @@ def geodetic_to_spherical(longitude, latitude, height):
     See also
     --------
     spherical_to_geodetic : Convert from geocentric spherical to geodetic coordinates.
+
+    Examples
+    --------
+
+    In the poles, the radius should be the reference ellipsoid's semi-minor axis:
+
+    >>> import harmonica as hm
+    >>> spherical = hm.geodetic_to_spherical(longitude=0, latitude=90, height=0)
+    >>> print(", ".join("{:.4f}".format(i) for i in spherical))
+    0.0000, 90.0000, 6356752.3142
+    >>> print("{:.4f}".format(hm.get_ellipsoid().semiminor_axis))
+    6356752.3142
+
+    In  the equator, it should be the semi-major axis:
+
+    >>> spherical = hm.geodetic_to_spherical(longitude=0, latitude=0, height=0)
+    >>> print(", ".join("{:.4f}".format(i) for i in spherical))
+    0.0000, 0.0000, 6378137.0000
+    >>> print("{:.4f}".format(hm.get_ellipsoid().semimajor_axis))
+    6378137.0000
+
     """
     # Get ellipsoid
     ellipsoid = get_ellipsoid()
@@ -78,7 +99,7 @@ def spherical_to_geodetic(longitude, spherical_latitude, radius):
     longitude : array
         Longitude coordinates on geodetic coordinate system in degrees.
         The longitude coordinates are not modified during this conversion.
-    spherical_latitude : array
+    latitude : array
         Converted latitude coordinates on geodetic coordinate system in degrees.
     height : array
         Converted ellipsoidal height coordinates in meters.
@@ -86,6 +107,32 @@ def spherical_to_geodetic(longitude, spherical_latitude, radius):
     See also
     --------
     geodetic_to_spherical : Convert from geodetic to geocentric spherical coordinates.
+
+    Examples
+    --------
+
+    In the poles and equator, using the semi-minor or semi-major axis of the ellipsoid
+    as the radius should yield 0 height:
+
+    >>> import harmonica as hm
+    >>> geodetic = hm.spherical_to_geodetic(
+    ...     longitude=0, spherical_latitude=90, radius=hm.get_ellipsoid().semiminor_axis
+    ... )
+    >>> print(", ".join("{:.1f}".format(i) for i in geodetic))
+    0.0, 90.0, 0.0
+    >>> geodetic = hm.spherical_to_geodetic(
+    ...     longitude=0, spherical_latitude=0, radius=hm.get_ellipsoid().semimajor_axis
+    ... )
+    >>> print(", ".join("{:.1f}".format(i) for i in geodetic))
+    0.0, 0.0, 0.0
+    >>> geodetic = hm.spherical_to_geodetic(
+    ...     longitude=0,
+    ...     spherical_latitude=-90,
+    ...     radius=hm.get_ellipsoid().semiminor_axis + 2
+    ... )
+    >>> print(", ".join("{:.1f}".format(i) for i in geodetic))
+    0.0, -90.0, 2.0
+
     """
     # Get ellipsoid
     ellipsoid = get_ellipsoid()

--- a/harmonica/tests/test_coordinates.py
+++ b/harmonica/tests/test_coordinates.py
@@ -131,7 +131,7 @@ def test_spherical_to_geodetic_on_poles():
             npt.assert_allclose(radius, height + ellipsoid.semiminor_axis, rtol=rtol)
 
 
-def test_identity():
+def test_spherical_to_geodetic_identity():
     "Test if geodetic_to_spherical and spherical_to_geodetic is the identity operator"
     rtol = 1e-10
     longitude = np.linspace(0, 350, 36)

--- a/harmonica/tests/test_coordinates.py
+++ b/harmonica/tests/test_coordinates.py
@@ -28,7 +28,7 @@ def test_geodetic_to_spherical_with_spherical_ellipsoid():
         latitude = np.linspace(-90, 90, size)
         height = np.linspace(-0.2, 0.2, size)
         spherical_longitude, spherical_latitude, radius = geodetic_to_spherical(
-            [longitude, latitude, height]
+            longitude, latitude, height
         )
         npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
         npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
@@ -46,7 +46,7 @@ def test_geodetic_to_spherical_on_equator():
         with set_ellipsoid(ellipsoid_name):
             ellipsoid = get_ellipsoid()
             spherical_longitude, spherical_latitude, radius = geodetic_to_spherical(
-                [longitude, latitude, height]
+                longitude, latitude, height
             )
             npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
             npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
@@ -64,7 +64,7 @@ def test_geodetic_to_spherical_on_poles():
         with set_ellipsoid(ellipsoid_name):
             ellipsoid = get_ellipsoid()
             spherical_longitude, spherical_latitude, radius = geodetic_to_spherical(
-                [longitude, latitude, height]
+                longitude, latitude, height
             )
             npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
             npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
@@ -86,7 +86,7 @@ def test_spherical_to_geodetic_with_spherical_ellipsoid():
         spherical_latitude = np.linspace(-90, 90, size)
         radius = np.linspace(0.8, 1.2, size)
         longitude, latitude, height = spherical_to_geodetic(
-            [spherical_longitude, spherical_latitude, radius]
+            spherical_longitude, spherical_latitude, radius
         )
         npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
         npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
@@ -104,7 +104,7 @@ def test_spherical_to_geodetic_on_equator():
             spherical_longitude = np.linspace(0, 180, size)
             radius = np.linspace(-1e4, 1e4, size) + ellipsoid.semimajor_axis
             longitude, latitude, height = spherical_to_geodetic(
-                [spherical_longitude, spherical_latitude, radius]
+                spherical_longitude, spherical_latitude, radius
             )
             npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
             npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
@@ -124,7 +124,7 @@ def test_spherical_to_geodetic_on_poles():
                 [np.linspace(-1e4, 1e4, size) + ellipsoid.semiminor_axis] * 2
             )
             longitude, latitude, height = spherical_to_geodetic(
-                [spherical_longitude, spherical_latitude, radius]
+                spherical_longitude, spherical_latitude, radius
             )
             npt.assert_allclose(spherical_longitude, longitude, rtol=rtol)
             npt.assert_allclose(spherical_latitude, latitude, rtol=rtol)
@@ -140,6 +140,6 @@ def test_identity():
     coordinates = np.meshgrid(longitude, latitude, height)
     for ellipsoid_name in KNOWN_ELLIPSOIDS:
         with set_ellipsoid(ellipsoid_name):
-            spherical_coordinates = geodetic_to_spherical(coordinates)
-            reconverted_coordinates = spherical_to_geodetic(spherical_coordinates)
+            spherical_coordinates = geodetic_to_spherical(*coordinates)
+            reconverted_coordinates = spherical_to_geodetic(*spherical_coordinates)
             npt.assert_allclose(coordinates, reconverted_coordinates, rtol=rtol)


### PR DESCRIPTION
Geographic coordinates conversion functions now get the full coordinates
as arguments rather than only the `latitude` and `radius`/`height`, and returns
the full set of converted coordinates.
The previous implementation was inconvenient for real applications.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
