### PR TITLE
Add mean radius property to ReferenceEllipsoid

### DIFF
--- a/doc/references.rst
+++ b/doc/references.rst
@@ -8,4 +8,4 @@ References
 .. [LiGotze2001] Li, X. and H. J. Gotze, 2001, Tutorial: Ellipsoid, geoid, gravity, geodesy, and geophysics, Geophysics, 66(6), p. 1660-1668, doi:`10.1190/1.1487109 <https://doi.org/10.1190/1.1487109>`__
 .. [TurcotteSchubert2014] Turcotte, D. L., & Schubert, G. (2014). Geodynamics (3 edition). Cambridge, United Kingdom: Cambridge University Press.
 .. [Vermeille2002] Vermeille, H., 2002. Direct transformation from geocentric coordinates to geodetic coordinates. Journal of Geodesy. 76. 451-454. doi:`10.1007/s00190-002-0273-6 <https://doi.org/10.1007/s00190-002-0273-6>`__
-.. [Moritz2000] Moritz, H. (2000). Geodetic Reference System 1980. Journal of Geodesy, 74(1), 128–133. https://doi.org/10.1007/s001900050278
+.. [Moritz2000] Moritz, H. (2000). Geodetic Reference System 1980. Journal of Geodesy, 74(1), 128–133. doi:`10.1007/s001900050278 <https://doi.org/10.1007/s001900050278>`__

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -8,3 +8,4 @@ References
 .. [LiGotze2001] Li, X. and H. J. Gotze, 2001, Tutorial: Ellipsoid, geoid, gravity, geodesy, and geophysics, Geophysics, 66(6), p. 1660-1668, doi:`10.1190/1.1487109 <https://doi.org/10.1190/1.1487109>`__
 .. [TurcotteSchubert2014] Turcotte, D. L., & Schubert, G. (2014). Geodynamics (3 edition). Cambridge, United Kingdom: Cambridge University Press.
 .. [Vermeille2002] Vermeille, H., 2002. Direct transformation from geocentric coordinates to geodetic coordinates. Journal of Geodesy. 76. 451-454. doi:`10.1007/s00190-002-0273-6 <https://doi.org/10.1007/s00190-002-0273-6>`__
+.. [Moritz2000] Moritz, H. (2000). Geodetic Reference System 1980. Journal of Geodesy, 74(1), 128–133. https://doi.org/10.1007/s001900050278

--- a/harmonica/ellipsoid.py
+++ b/harmonica/ellipsoid.py
@@ -144,7 +144,9 @@ class ReferenceEllipsoid:
 
     @property
     def mean_radius(self):
-        "The arithmetic mean radius [meters]"
+        """
+        The arithmetic mean radius :math:`R_1 = (2a + b) /3` [Moritz2000]_ [meters]
+        """
         return 1 / 3 * (2 * self.semimajor_axis + self.semiminor_axis)
 
     @property

--- a/harmonica/ellipsoid.py
+++ b/harmonica/ellipsoid.py
@@ -99,6 +99,8 @@ class ReferenceEllipsoid:
     8.1819190842621e-02
     >>> print("{:.13e}".format(wgs84.second_eccentricity))
     8.2094437949696e-02
+    >>> print("{:.4f}".format(wgs84.mean_radius))
+    6371008.7714
     >>> print("{:.14f}".format(wgs84.emm))
     0.00344978650684
     >>> print("{:.10f}".format(wgs84.gravity_equator))
@@ -139,6 +141,11 @@ class ReferenceEllipsoid:
     def second_eccentricity(self):
         "The second eccentricity [adimensional]"
         return self.linear_eccentricity / self.semiminor_axis
+
+    @property
+    def mean_radius(self):
+        "The arithmetic mean radius [meters]"
+        return 1 / 3 * (2 * self.semimajor_axis + self.semiminor_axis)
 
     @property
     def emm(self):


### PR DESCRIPTION
Add `mean_radius` property to `ReferenceEllipsoid` class to compute the
arithmetic mean radius of the ellipsoid defined after Moritz (2000).

Moritz (2000) https://doi.org/10.1007/s001900050278


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
