### PR TITLE
Fix wrong docstring on script of tesseroid tests

### DIFF
--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -1,5 +1,5 @@
 """
-Test forward modelling for point masses.
+Test forward modelling for tesseroids.
 """
 import numpy as np
 import numpy.testing as npt


### PR DESCRIPTION
The docstring of the script containing test functions for tesseroids was wrong.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.