### PR TITLE
Fix require_numba decorator

### DIFF
--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -22,6 +22,9 @@ from ..forward.tesseroid import (
     MAX_DISCRETIZATIONS,
 )
 
+# Define the accuracy threshold for tesseroids (0.1%) as a relative error (0.001)
+ACCURACY_THRESHOLD = 1e-3
+
 
 @pytest.mark.use_numba
 def test_single_tesseroid():
@@ -443,12 +446,6 @@ def test_two_dimensional_adaptive_discretization():
 # ------------------------------------------------------------------
 # Compare numerical result vs analytical solution of spherical shell
 # ------------------------------------------------------------------
-@pytest.fixture
-def accuracy_threshold():
-    "Return the accuracy threshold for tesseroids (0.1%) as a relative error (0.001)"
-    return 1e-3
-
-
 def spherical_shell_analytical(top, bottom, density, radius):
     "Compute analytical solution of gravity fields for an homogeneous spherical shell"
     potential = (
@@ -494,18 +491,16 @@ def test_spherical_shell_two_dim_adaptive_discret():  # pylint: disable=too-many
         for w, e in zip(west, east):
             for s, n in zip(south, north):
                 tesseroids.append([w, e, s, n, bottom, top])
-        # Compute gravitational fields of the spherical shell
-        numerical = {"potential": 0, "g_r": 0}
-        for field in numerical:
-            numerical[field] = tesseroid_gravity(
-                coordinates, tesseroids, density * np.ones(shape), field=field
-            )
         # Get analytical solutions
         analytical = spherical_shell_analytical(top, bottom, density, radius)
         # Assert analytical and numerical solution are bellow the accuracy threshold
-        for field in numerical:
-            np.assert_allclose(
-                analytical[field], numerical[field], rtol=accuracy_threshold
+        for field in analytical:
+            npt.assert_allclose(
+                analytical[field],
+                tesseroid_gravity(
+                    coordinates, tesseroids, density * np.ones(shape), field=field
+                ),
+                rtol=ACCURACY_THRESHOLD,
             )
 
 
@@ -535,21 +530,14 @@ def test_spherical_shell_three_dim_adaptive_discret():  # pylint: disable=too-ma
         for w, e in zip(west, east):
             for s, n in zip(south, north):
                 tesseroids.append([w, e, s, n, bottom, top])
-        # Compute gravitational fields of the spherical shell
-        numerical = {"potential": 0, "g_r": 0}
-        for tesseroid in tesseroids:
-            for field in numerical:
-                numerical[field] += tesseroid_gravity(
-                    coordinates,
-                    tesseroid,
-                    density,
-                    field=field,
-                    radial_adaptive_discretization=True,
-                )
         # Get analytical solutions
         analytical = spherical_shell_analytical(top, bottom, density, radius)
         # Assert analytical and numerical solution are bellow the accuracy threshold
-        for field in numerical:
-            np.assert_allclose(
-                analytical[field], numerical[field], rtol=accuracy_threshold
+        for field in analytical:
+            npt.assert_allclose(
+                analytical[field],
+                tesseroid_gravity(
+                    coordinates, tesseroids, density * np.ones(shape), field=field
+                ),
+                rtol=ACCURACY_THRESHOLD,
             )

--- a/harmonica/tests/utils.py
+++ b/harmonica/tests/utils.py
@@ -29,6 +29,5 @@ def require_numba(function):  # pylint: disable=unused-argument
     @pytest.mark.skipif(numba_is_disabled, reason="Numba jit is disabled")
     def function_wrapper():
         function()
-        return
 
     return function_wrapper

--- a/harmonica/tests/utils.py
+++ b/harmonica/tests/utils.py
@@ -28,6 +28,7 @@ def require_numba(function):  # pylint: disable=unused-argument
     @pytest.mark.use_numba
     @pytest.mark.skipif(numba_is_disabled, reason="Numba jit is disabled")
     def function_wrapper():
+        function()
         return
 
     return function_wrapper


### PR DESCRIPTION
Make function wrapper of require_numba decorator run the decorated function passed as
arguument. Refactor accuracy tests for tesseroids to solve some hidden mistakes produced
by previous untested lines.


Fixes #90


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.