### PR TITLE
Improve error message for invalid density array

### DIFF
--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -138,7 +138,8 @@ def tesseroid_gravity(
     # Sanity checks for tesseroids and computation points
     if density.size != tesseroids.shape[0]:
         raise ValueError(
-            "Density array must have the same size as number of tesseroids."
+            "Number of elements in density ({}) ".format(density.size)
+            + "mismatch the number of tesseroids ({})".format(tesseroids.shape[0])
         )
     _longitude_continuity(tesseroids)
     _check_tesseroids(tesseroids)


### PR DESCRIPTION
Add size of density array and number of tesseroids on the error message
when they mismatch in order to make clearer what's failing.

The improvement of such error messages was triggered after #98.


<!-- Please describe changes proposed and WHY you made them. If unsure, open an issue first to discuss the idea. -->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.