### PR TITLE
Remove attributes argument from check_is_fitted

### DIFF
--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -149,7 +149,7 @@ class EQLHarmonic(vdb.BaseGridder):
             The data values evaluated on the given points.
         """
         # We know the gridder has been fitted if it has the coefs_
-        check_is_fitted(self, ["coefs_"])
+        check_is_fitted(self)
         shape = np.broadcast(*coordinates[:3]).shape
         size = np.broadcast(*coordinates[:3]).size
         dtype = coordinates[0].dtype


### PR DESCRIPTION
The attributes argument for the sklearn.utils.validation.check_is_fitted
function is going to be deprecated. Remove the attributes passed to the
check_is_fitted function used on the EQLHarmonic.predict method.


<!-- Please describe changes proposed and WHY you made them. If unsure, open an issue first to discuss the idea. -->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #133


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.