### PR TITLE
Revert the use of attributes in check_is_fitted 

### DIFF
--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -149,7 +149,7 @@ class EQLHarmonic(vdb.BaseGridder):
             The data values evaluated on the given points.
         """
         # We know the gridder has been fitted if it has the coefs_
-        check_is_fitted(self)
+        check_is_fitted(self, ["coefs_"])
         shape = np.broadcast(*coordinates[:3]).shape
         size = np.broadcast(*coordinates[:3]).size
         dtype = coordinates[0].dtype


### PR DESCRIPTION
Rollback the changes in #134 because scikit-learn reverted the deprecation of
attributes in check_is_fitted. See scikit-learn/scikit-learn#15947