### PR TITLE
WIP Topographic correction in spherical coordinates

### DIFF
--- a/harmonica/gravity_corrections.py
+++ b/harmonica/gravity_corrections.py
@@ -2,6 +2,7 @@
 Gravity corrections like Normal Gravity and Bouguer corrections.
 """
 import numpy as np
+import verde as vd
 
 from .constants import GRAVITATIONAL_CONST
 
@@ -69,3 +70,91 @@ def bouguer_correction(topography, density_crust=2670, density_water=1040):
     density[oceans] = -1 * (density_water - density_crust)
     bouguer = 1e5 * 2 * np.pi * GRAVITATIONAL_CONST * density * topography
     return bouguer
+
+
+def topographic_correction(
+    coordinates,
+    topography,
+    ellipsoid,
+    field="g_z",
+    density_crust=2670,
+    density_water=1040,
+):
+    """
+    Topographic correction for gravity data in spherical coordinates.
+
+    Calculates the gravitational effect of topography and the water layer using
+    a spherical approximation. Modeling is done with tesseroids (see
+    :func:`harmonica.tesseroid_gravity`).
+
+    The topography must be a regular grid in geodetic coordinates. Prior to
+    modeling, the topography grid will be converted to spherical geocentric
+    coordinates (longitude, spherical latitude, and radius). After conversion,
+    the topography must be interpolated back onto a regular grid.
+
+    Parameters
+    ----------
+    coordinates : tuple of arrays
+        Arrays containing longitude, geodetic latitude, and geometric height of
+        the computation points. Coordinates must be defined on a geodetic
+        system (using the given *ellipsoid*). Both longitude and latitude
+        should be in degrees and height in meters.
+    topography : :class:`xarray.DataArray`
+        Grid of topographic height (geometric) and bathymetric depth in meters.
+        Should be referenced to the ellipsoid (ie, geometric heights). The grid
+        must have dimensions ``"latitude"`` and ``"longitude"`` and be evenly
+        spaced.
+    ellipsoid : :class:`boule.Ellipsoid`
+        The reference ellipsoid for the geodetic coordinates. Will be used to
+        convert to geocentric spherical coordinates and as a reference for zero
+        topography.
+    field : str
+        Gravitational component that will to be computed. Can be any accepted
+        by :func:`harmonica.tesseroid_gravity`.
+    density_crust : float
+        Density of the crust in :math:`kg/m^3`.
+        Used as the density of topography on land and the density of the normal
+        Earth's crust in the oceans.
+    density_water : float
+        Density of water in :math:`kg/m^3`.
+
+    Returns
+    -------
+    topographic_effect : array
+        Array with the effect of topography calculated on *coordinates*. Will
+        have a shape compatible with *coordinates*.
+
+    """
+    coordinates = ellipsoid.geodetic_to_spherical(*coordinates)
+    topography_table = vd.grid_to_table(topography)
+    topography_spherical = _geodetic_to_spherical_topography(
+        topography_table, ellipsoid, _mean_grid_spacing(topography)
+    )
+    data = vd.grid_to_table(topography_spherical)
+    reference = ellipsoid.geodetic_to_spherical(
+        None, data.latitude, np.zeros_like(topo.latitude)
+    )[2]
+
+
+def _geodetic_to_spherical_topography(table, ellipsoid, spacing):
+    """
+    """
+    latitude_spherical, radius = ellipsoid.geodetic_to_spherical(
+        None, table.latitude, table.topography
+    )[1:]
+    gridder = vd.ScipyGridder(method="nearest")
+    gridder.fit((table.longitude, latitude_spherical), radius)
+    topography_spherical = gridder.grid(
+        spacing=spacing, data_names=["radius"], dims=["latitude", "longitude"]
+    )
+    return topography_spherical
+
+
+def _mean_grid_spacing(grid):
+    """
+    """
+    spacing = tuple(
+        np.mean(np.abs(coord.values[1:] - coord.values[:-1]))
+        for coord in [topography.latitude, topography.longitude]
+    )
+    return spacing

--- a/terrain_correction.ipynb
+++ b/terrain_correction.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boule as bl\n",
+    "import harmonica as hm\n",
+    "import verde as vd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:     (latitude: 37, longitude: 73)\n",
+       "Coordinates:\n",
+       "  * longitude   (longitude) float64 -180.0 -175.0 -170.0 ... 170.0 175.0 180.0\n",
+       "  * latitude    (latitude) float64 -90.0 -85.0 -80.0 -75.0 ... 80.0 85.0 90.0\n",
+       "Data variables:\n",
+       "    topography  (latitude, longitude) float64 2.762e+03 2.762e+03 ... -4.179e+03</pre>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:     (latitude: 37, longitude: 73)\n",
+       "Coordinates:\n",
+       "  * longitude   (longitude) float64 -180.0 -175.0 -170.0 ... 170.0 175.0 180.0\n",
+       "  * latitude    (latitude) float64 -90.0 -85.0 -80.0 -75.0 ... 80.0 85.0 90.0\n",
+       "Data variables:\n",
+       "    topography  (latitude, longitude) float64 2.762e+03 2.762e+03 ... -4.179e+03"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topography = hm.datasets.fetch_topography_earth().loc[dict(longitude=slice(-180, 180, 10), latitude=slice(-90, 90, 10))]\n",
+    "topography"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ellipsoid = bl.WGS84"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo = vd.grid_to_table(topography)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dlats = topography.latitude.values[1:] - topography.latitude.values[:-1]\n",
+    "dlons = topography.longitude.values[1:] - topography.longitude.values[:-1]\n",
+    "dlon = dlons[0]\n",
+    "dlat = dlats[0]\n",
+    "assert np.allclose(dlons, dlon)\n",
+    "assert np.allclose(dlats, dlat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "west = topography.longitude.values - dlon/2\n",
+    "east = topography.longitude.values + dlon/2\n",
+    "west[west > 360] = 360\n",
+    "west[west < -180] = -180\n",
+    "east[east > 360] = 360\n",
+    "east[east < -180] = -180\n",
+    "south = topography.latitude.values - dlat/2\n",
+    "south[south > 90] = 90\n",
+    "south[south < -90] = -90\n",
+    "north = topography.latitude.values + dlat/2\n",
+    "north[north > 90] = 90\n",
+    "north[north < -90] = -90\n",
+    "reference = ellipsoid.geodetic_to_spherical(None, topo.latitude, np.zeros_like(topo.latitude))[2]\n",
+    "radius = ellipsoid.geodetic_to_spherical(None, topo.latitude, topo.topography)[2]\n",
+    "index = np.arange(radius.size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coordinates = ellipsoid.geodetic_to_spherical(topo.longitude, topo.latitude, np.full_like(topo.latitude, 100e3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zero_height = np.zeros_like(north)\n",
+    "north_sph = ellipsoid.geodetic_to_spherical(None, north, zero_height)[1]\n",
+    "south_sph = ellipsoid.geodetic_to_spherical(None, south, zero_height)[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shape = topography.topography.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Invalid tesseroid or tesseroids. The bottom radius boundary can't be greater than the top one.\n\tInvalid tesseroid: [-1.80000000e+02 -1.77500000e+02 -8.25000000e+01 -7.75000000e+01\n  6.35691611e+06  6.35682711e+06]\n\tInvalid tesseroid: [-1.77500000e+02 -1.72500000e+02 -8.25000000e+01 -7.75000000e+01\n  6.35675231e+06  6.35673831e+06]\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-87-cbe9e195678f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      8\u001b[0m         \u001b[0mtesseroids\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mwest\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mj\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0meast\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mj\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msouth\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnorth\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreference\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mt\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mradius\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mt\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0mdensity\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfull_like\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mbatch\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m2670\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m     \u001b[0mfield\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mhm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtesseroid_gravity\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcoordinates\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtesseroids\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfield\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"g_z\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdensity\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdensity\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/src/harmonica/harmonica/forward/tesseroid.py\u001b[0m in \u001b[0;36mtesseroid_gravity\u001b[0;34m(coordinates, tesseroids, density, field, distance_size_ratii, glq_degrees, stack_size, max_discretizations, radial_adaptive_discretization, dtype, disable_checks)\u001b[0m\n\u001b[1;32m    155\u001b[0m                 \u001b[0;34m+\u001b[0m \u001b[0;34m\"mismatch the number of tesseroids ({})\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtesseroids\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    156\u001b[0m             )\n\u001b[0;32m--> 157\u001b[0;31m         \u001b[0mtesseroids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_check_tesseroids\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtesseroids\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    158\u001b[0m         \u001b[0m_check_points_outside_tesseroids\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcoordinates\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtesseroids\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    159\u001b[0m     \u001b[0;31m# Get value of D (distance_size_ratio)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/src/harmonica/harmonica/forward/tesseroid.py\u001b[0m in \u001b[0;36m_check_tesseroids\u001b[0;34m(tesseroids)\u001b[0m\n\u001b[1;32m    635\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mtess\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mtesseroids\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0minvalid\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    636\u001b[0m             \u001b[0merr_msg\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0;34m\"\\tInvalid tesseroid: {}\\n\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtess\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 637\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merr_msg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    638\u001b[0m     \u001b[0;31m# Check if longitudinal boundaries are inside the [-180, 360] interval\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    639\u001b[0m     invalid = np.logical_or(\n",
+      "\u001b[0;31mValueError\u001b[0m: Invalid tesseroid or tesseroids. The bottom radius boundary can't be greater than the top one.\n\tInvalid tesseroid: [-1.80000000e+02 -1.77500000e+02 -8.25000000e+01 -7.75000000e+01\n  6.35691611e+06  6.35682711e+06]\n\tInvalid tesseroid: [-1.77500000e+02 -1.72500000e+02 -8.25000000e+01 -7.75000000e+01\n  6.35675231e+06  6.35673831e+06]\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch_size = 10\n",
+    "batches = [index[i:i + batch_size] for i in range(0, index.size, batch_size)]\n",
+    "field = np.zeros_like(topo.topography)\n",
+    "for batch in batches:\n",
+    "    tesseroids = []\n",
+    "    for t in batch:\n",
+    "        i, j = np.unravel_index(t, shape)\n",
+    "        tesseroids.append([west[j], east[j], south[i], north[i], reference[t], radius[t]])\n",
+    "    density = np.full_like(batch, 2670)\n",
+    "    field += hm.tesseroid_gravity(coordinates, tesseroids, field=\"g_z\", density=density)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.unravel_index(batches[0], shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:harmonica]",
+   "language": "python",
+   "name": "conda-env-harmonica-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/terrain_correction.ipynb
+++ b/terrain_correction.ipynb
@@ -50,6 +50,29 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'DataArray' object has no attribute 'data_vars'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-24-406ae588b82c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mvd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgrid_to_table\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtopography\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtopography\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/miniconda3/envs/harmonica/lib/python3.7/site-packages/verde/utils.py\u001b[0m in \u001b[0;36mgrid_to_table\u001b[0;34m(grid)\u001b[0m\n\u001b[1;32m    266\u001b[0m         \u001b[0mcoordinate_names\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mcoordinates\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    267\u001b[0m     }\n\u001b[0;32m--> 268\u001b[0;31m     \u001b[0mvariable_name\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mgrid\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata_vars\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeys\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    269\u001b[0m     \u001b[0mvariable_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgrid\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_array\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    270\u001b[0m     variable_arrays = variable_data.reshape(\n",
+      "\u001b[0;32m~/miniconda3/envs/harmonica/lib/python3.7/site-packages/xarray/core/common.py\u001b[0m in \u001b[0;36m__getattr__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m    231\u001b[0m                     \u001b[0;32mreturn\u001b[0m \u001b[0msource\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m         raise AttributeError(\n\u001b[0;32m--> 233\u001b[0;31m             \u001b[0;34m\"{!r} object has no attribute {!r}\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    234\u001b[0m         )\n\u001b[1;32m    235\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'DataArray' object has no attribute 'data_vars'"
+     ]
+    }
+   ],
+   "source": [
+    "vd.grid_to_table(topography.topography)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
    "outputs": [],

--- a/terrain_correction.ipynb
+++ b/terrain_correction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -38,7 +38,7 @@
        "    topography  (latitude, longitude) float64 2.762e+03 2.762e+03 ... -4.179e+03"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,11 +59,235 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.0"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spacing = np.mean(np.abs(topography.latitude.values[1:] - topography.latitude.values[:-1]))\n",
+    "spacing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
     "topo = vd.grid_to_table(topography)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo[\"latitude_spherical\"], topo[\"radius\"] = ellipsoid.geodetic_to_spherical(topo.longitude, topo.latitude, topo.topography)[1:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>topography</th>\n",
+       "      <th>latitude_spherical</th>\n",
+       "      <th>radius</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-180.0</td>\n",
+       "      <td>-90.0</td>\n",
+       "      <td>2762.0</td>\n",
+       "      <td>-90.000000</td>\n",
+       "      <td>6.359514e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>-180.0</td>\n",
+       "      <td>-85.0</td>\n",
+       "      <td>2762.0</td>\n",
+       "      <td>-84.966490</td>\n",
+       "      <td>6.359678e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>-180.0</td>\n",
+       "      <td>-80.0</td>\n",
+       "      <td>2762.0</td>\n",
+       "      <td>-79.934007</td>\n",
+       "      <td>6.360164e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>-180.0</td>\n",
+       "      <td>-75.0</td>\n",
+       "      <td>2762.0</td>\n",
+       "      <td>-74.903549</td>\n",
+       "      <td>6.360958e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>-180.0</td>\n",
+       "      <td>-70.0</td>\n",
+       "      <td>2762.0</td>\n",
+       "      <td>-69.876047</td>\n",
+       "      <td>6.362034e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2696</th>\n",
+       "      <td>180.0</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>-4179.0</td>\n",
+       "      <td>69.875912</td>\n",
+       "      <td>6.355093e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2697</th>\n",
+       "      <td>180.0</td>\n",
+       "      <td>75.0</td>\n",
+       "      <td>-4179.0</td>\n",
+       "      <td>74.903444</td>\n",
+       "      <td>6.354017e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2698</th>\n",
+       "      <td>180.0</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>-4179.0</td>\n",
+       "      <td>79.933935</td>\n",
+       "      <td>6.353223e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2699</th>\n",
+       "      <td>180.0</td>\n",
+       "      <td>85.0</td>\n",
+       "      <td>-4179.0</td>\n",
+       "      <td>84.966453</td>\n",
+       "      <td>6.352737e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2700</th>\n",
+       "      <td>180.0</td>\n",
+       "      <td>90.0</td>\n",
+       "      <td>-4179.0</td>\n",
+       "      <td>90.000000</td>\n",
+       "      <td>6.352573e+06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2701 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      longitude  latitude  topography  latitude_spherical        radius\n",
+       "0        -180.0     -90.0      2762.0          -90.000000  6.359514e+06\n",
+       "1        -180.0     -85.0      2762.0          -84.966490  6.359678e+06\n",
+       "2        -180.0     -80.0      2762.0          -79.934007  6.360164e+06\n",
+       "3        -180.0     -75.0      2762.0          -74.903549  6.360958e+06\n",
+       "4        -180.0     -70.0      2762.0          -69.876047  6.362034e+06\n",
+       "...         ...       ...         ...                 ...           ...\n",
+       "2696      180.0      70.0     -4179.0           69.875912  6.355093e+06\n",
+       "2697      180.0      75.0     -4179.0           74.903444  6.354017e+06\n",
+       "2698      180.0      80.0     -4179.0           79.933935  6.353223e+06\n",
+       "2699      180.0      85.0     -4179.0           84.966453  6.352737e+06\n",
+       "2700      180.0      90.0     -4179.0           90.000000  6.352573e+06\n",
+       "\n",
+       "[2701 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:    (latitude: 37, longitude: 73)\n",
+       "Coordinates:\n",
+       "  * longitude  (longitude) float64 -180.0 -175.0 -170.0 ... 170.0 175.0 180.0\n",
+       "  * latitude   (latitude) float64 -90.0 -85.0 -80.0 -75.0 ... 80.0 85.0 90.0\n",
+       "Data variables:\n",
+       "    radius     (latitude, longitude) float64 6.36e+06 6.36e+06 ... 6.353e+06\n",
+       "Attributes:\n",
+       "    metadata:  Generated by ScipyGridder(extra_args=None, method=&#x27;nearest&#x27;)</pre>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:    (latitude: 37, longitude: 73)\n",
+       "Coordinates:\n",
+       "  * longitude  (longitude) float64 -180.0 -175.0 -170.0 ... 170.0 175.0 180.0\n",
+       "  * latitude   (latitude) float64 -90.0 -85.0 -80.0 -75.0 ... 80.0 85.0 90.0\n",
+       "Data variables:\n",
+       "    radius     (latitude, longitude) float64 6.36e+06 6.36e+06 ... 6.353e+06\n",
+       "Attributes:\n",
+       "    metadata:  Generated by ScipyGridder(extra_args=None, method='nearest')"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "interp = vd.ScipyGridder(method=\"nearest\").fit((topo.longitude, topo.latitude_spherical), topo.radius)\n",
+    "topo_spherical = interp.grid(spacing=spacing, data_names=[\"radius\"], dims=[\"latitude\", \"longitude\"])\n",
+    "topo_spherical"
    ]
   },
   {


### PR DESCRIPTION
Add a function `topographic_correction` that calculates the effect of topography and water in spherical coordinates using tesseroids. The function converts the topography from geodetic (the most common input type) to geocentric spherical. The conversion requires the data to be interpolated back on a regular grid (using nearest neighbours by default).


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
