### PR TITLE
Replace global Zenodo DOI on badges and citation

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -5,7 +5,7 @@ This is research software **made by scientists**. Citations help us justify the
 effort that goes into building and maintaining this project.
 
 If you used this software in your research, please consider
-citing the following source: https://doi.org/10.5281/zenodo.3628742
+citing the following source: https://doi.org/10.5281/zenodo.3628741
 
 The link above includes full citation information and export formats (BibTeX,
 Mendeley, etc).

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. image:: https://img.shields.io/pypi/pyversions/harmonica.svg?style=flat-square
     :alt: Compatible Python versions.
     :target: https://pypi.python.org/pypi/harmonica
-.. image:: https://img.shields.io/badge/doi-10.5281%2Fzenodo.3628742-blue.svg?style=flat-square
+.. image:: https://img.shields.io/badge/doi-10.5281%2Fzenodo.3628741-blue.svg?style=flat-square
     :alt: Digital Object Identifier for the Zenodo archive
-    :target: https://doi.org/10.5281/zenodo.3628742
+    :target: https://doi.org/10.5281/zenodo.3628741
 
 
 .. placeholder-for-doc-index


### PR DESCRIPTION
Replace the reserved Zenodo DOI for the first release with the global
Zenodo DOI for Harmonica. Zenodo makes available the global DOI of the
release after it's released. So, the only DOI available at the time was
the one corresponding to the first release: v0.1.0. It's better to have
the global DOI on the badge from `README.rst` and on citation
instructions on `CITATION.rst`.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.