### PR TITLE
Add CI builds for Python 3.8

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
   displayName: 'Mac'
 
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
 
   variables:
     CONDA_REQUIREMENTS: requirements.txt
@@ -81,6 +81,9 @@ jobs:
 
   strategy:
     matrix:
+      Python38:
+        python.version: '3.8'
+        PYTHON: '3.8'
       Python37:
         python.version: '3.7'
         PYTHON: '3.7'
@@ -172,6 +175,9 @@ jobs:
 
   strategy:
     matrix:
+      Python38:
+        python.version: '3.8'
+        PYTHON: '3.8'
       Python37:
         python.version: '3.7'
         PYTHON: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ env:
 # Specify the build configurations. Be sure to only deploy from a single build.
 matrix:
     include:
+        - name: "Linux - Python 3.8"
+          os: linux
+          env:
+              - PYTHON=3.8
         - name: "Linux - Python 3.7"
           os: linux
           env:

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,11 @@ CLASSIFIERS = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: {}".format(LICENSE),
 ]
 PLATFORMS = "Any"


### PR DESCRIPTION
Set the metadata flags on `setup.py` to include 3.8 and specify that
it's Python 3 only.

Fixes #147 





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
