### PR TITLE
Fix wrong name of EQLHarmonic class on docstrings

### DIFF
--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -76,8 +76,8 @@ class EQLHarmonic(vdb.BaseGridder):
     region_ : tuple
         The boundaries (``[W, E, S, N]``) of the data used to fit the
         interpolator. Used as the default region for the
-        :meth:`~harmonica.HarmonicEQL.grid` and
-        :meth:`~harmonica.HarmonicEQL.scatter` methods.
+        :meth:`~harmonica.EQLHarmonic.grid` and
+        :meth:`~harmonica.EQLHarmonic.scatter` methods.
     """
 
     def __init__(self, damping=None, points=None, relative_depth=500):
@@ -90,8 +90,8 @@ class EQLHarmonic(vdb.BaseGridder):
         Fit the coefficients of the equivalent layer.
 
         The data region is captured and used as default for the
-        :meth:`~harmonica.HarmonicEQL.grid` and
-        :meth:`~harmonica.HarmonicEQL.scatter` methods.
+        :meth:`~harmonica.EQLHarmonic.grid` and
+        :meth:`~harmonica.EQLHarmonic.scatter` methods.
 
         All input arrays must have the same shape.
 
@@ -133,7 +133,7 @@ class EQLHarmonic(vdb.BaseGridder):
         """
         Evaluate the estimated equivalent layer on the given set of points.
 
-        Requires a fitted estimator (see :meth:`~harmonica.HarmonicEQL.fit`).
+        Requires a fitted estimator (see :meth:`~harmonica.EQLHarmonic.fit`).
 
         Parameters
         ----------


### PR DESCRIPTION
`EQLHarmonca` docstrings were wrongly pointing to itself as the drafted
"`HarmonicEQL`" class. Replace `HarmonicEQL` for `EQLHarmonic`.