### PR TITLE
Replace Cartesian distance for Euclidean distance

### DIFF
--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -41,7 +41,7 @@ class EQLHarmonic(vdb.BaseGridder):
     source are estimated through linear least-squares with damping (Tikhonov
     0th order) regularization.
 
-    The Green's function for point mass effects used is the inverse Cartesian
+    The Green's function for point mass effects used is the inverse Euclidean
     distance between the grid coordinates and the point source:
 
     .. math::
@@ -234,7 +234,7 @@ class EQLHarmonicSpherical(EQLHarmonic):
     source are estimated through linear least-squares with damping (Tikhonov
     0th order) regularization.
 
-    The Green's function for point mass effects used is the inverse Cartesian
+    The Green's function for point mass effects used is the inverse Euclidean
     distance between the grid coordinates and the point source:
 
     .. math::


### PR DESCRIPTION
Now, docstrings of Equivalent Layer classes properly describe the
Greens' function as the _inverse Euclidean distance_.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.