### PR TITLE
Update EQLs after last changes on Verde BaseGridder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,6 @@ before_install:
 
 # Install the package that we want to test
 install:
-    # Change Travis wait time to 20 mins
-    - travis_wait 20 mvn install
     # Make a binary wheel for our package and install it
     - python setup.py bdist_wheel
     - pip install dist/*
@@ -75,7 +73,7 @@ install:
 # Run the actual tests and checks
 script:
     # Run the test suite
-    - make test
+    - travis_wait 20 make test
     # Build the documentation
     - make -C doc clean all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ before_install:
 
 # Install the package that we want to test
 install:
+    # Change Travis wait time to 20 mins
+    - travis_wait 20 mvn install
     # Make a binary wheel for our package and install it
     - python setup.py bdist_wheel
     - pip install dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
 # Run the actual tests and checks
 script:
     # Run the test suite
-    - travis_wait 30 make test
+    - make test
     # Build the documentation
     - make -C doc clean all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
 # Run the actual tests and checks
 script:
     # Run the test suite
-    - travis_wait 20 make test
+    - travis_wait 30 make test
     # Build the documentation
     - make -C doc clean all
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
     - pandas
     - numba
     - pooch>=0.7.0
-    - verde
+    - verde>=1.5.0
     - xarray
     # Development requirements
     - boule

--- a/examples/eql/harmonic_spherical.py
+++ b/examples/eql/harmonic_spherical.py
@@ -58,7 +58,6 @@ print("R² score:", eql.score(coordinates, gravity_disturbance))
 grid = eql.grid(
     spacing=0.2,
     extra_coords=coordinates[-1].max(),
-    dims=["spherical_latitude", "longitude"],
     data_names=["gravity_disturbance"],
 )
 

--- a/examples/eql/harmonic_spherical.py
+++ b/examples/eql/harmonic_spherical.py
@@ -56,9 +56,7 @@ print("R² score:", eql.score(coordinates, gravity_disturbance))
 # maximum radius of the data, we're effectively upward-continuing the data.
 # The grid will be defined in spherical coordinates.
 grid = eql.grid(
-    spacing=0.2,
-    extra_coords=coordinates[-1].max(),
-    data_names=["gravity_disturbance"],
+    spacing=0.2, extra_coords=coordinates[-1].max(), data_names=["gravity_disturbance"],
 )
 
 # Mask grid points too far from data points

--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -85,6 +85,10 @@ class EQLHarmonic(vdb.BaseGridder):
         :meth:`~harmonica.EQLHarmonic.scatter` methods.
     """
 
+    # Set the default dimension names for generated outputs
+    # (pd.DataFrame, xr.Dataset, etc)
+    dims = ("latitude", "longitude")
+
     def __init__(
         self, damping=None, points=None, relative_depth=500,
     ):
@@ -278,6 +282,13 @@ class EQLHarmonicSpherical(EQLHarmonic):
         :meth:`~harmonica.EQLHarmonicSpherical.grid` and
         :meth:`~harmonica.EQLHarmonicSpherical.scatter` methods.
     """
+
+    # Set the default dimension names for generated outputs
+    # (pd.DataFrame, xr.Dataset, etc)
+    dims = ("spherical_latitude", "longitude")
+
+    # Overwrite the defalt name for the upward coordinate.
+    extra_coords_name = "radius"
 
     def __init__(
         self, damping=None, points=None, relative_depth=500,

--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -89,6 +89,9 @@ class EQLHarmonic(vdb.BaseGridder):
     # (pd.DataFrame, xr.Dataset, etc)
     dims = ("latitude", "longitude")
 
+    # Overwrite the defalt name for the upward coordinate.
+    extra_coords_name = "upward"
+
     def __init__(
         self, damping=None, points=None, relative_depth=500,
     ):

--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -87,7 +87,7 @@ class EQLHarmonic(vdb.BaseGridder):
 
     # Set the default dimension names for generated outputs
     # (pd.DataFrame, xr.Dataset, etc)
-    dims = ("latitude", "longitude")
+    dims = ("northing", "easting")
 
     # Overwrite the defalt name for the upward coordinate.
     extra_coords_name = "upward"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas
 numba
 pooch>=0.7.0
 xarray
-verde
+verde>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ INSTALL_REQUIRES = [
     "numba",
     "pooch>=0.7.0",
     "xarray",
-    "verde",
+    "verde>=1.5.0",
 ]
 PYTHON_REQUIRES = ">=3.6"
 


### PR DESCRIPTION
Overwrite `dims` and `extra_coords_names` class attributes of EQL gridders based on the coordinate system of the gridder.
Update gallery example fo spherical EQL. Avoid passing the `projection` argument when gridding the data and grid it directly into spherical coordinates.
Pin Verde to `>=1.5.0`.

Fixes #170, fixes #174.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
