### PR TITLE
Fix infinite loop on CIs after Numba v0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,11 @@ install:
 # Run the actual tests and checks
 script:
     # Run the test suite
-    - make test
+    # (explicit NUMBA_THREADING_LAYER to bypass Numba v0.5.0 bug that generate
+    # an infinite loop on CIs running Ubuntu)
+    - NUMBA_THREADING_LAYER=omp make test
     # Build the documentation
-    - make -C doc clean all
+    - NUMBA_THREADING_LAYER=omp make -C doc clean all
 
 # Things to do if the build is successful
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ script:
     # Run the test suite
     # (explicit NUMBA_THREADING_LAYER to bypass Numba v0.5.0 bug that generate
     # an infinite loop on CIs running Ubuntu)
+    # https://github.com/numba/numba/issues/5983
     - NUMBA_THREADING_LAYER=workqueue make test
     # Build the documentation
     - NUMBA_THREADING_LAYER=workqueue make -C doc clean all

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,9 @@ script:
     # Run the test suite
     # (explicit NUMBA_THREADING_LAYER to bypass Numba v0.5.0 bug that generate
     # an infinite loop on CIs running Ubuntu)
-    - NUMBA_THREADING_LAYER=omp make test
+    - NUMBA_THREADING_LAYER=workqueue make test
     # Build the documentation
-    - NUMBA_THREADING_LAYER=omp make -C doc clean all
+    - NUMBA_THREADING_LAYER=workqueue make -C doc clean all
 
 # Things to do if the build is successful
 after_success:


### PR DESCRIPTION
Set `NUMBA_THREADING_LAYER` to `workqueue` on Travis CIs running Ubuntu.
Solution obtained from https://github.com/numba/numba/issues/5983.





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
