### PR TITLE
Run black and require >=20.8b1

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
 
   variables:
-    CONDA_INSTALL_EXTRA: "black flake8 pylint"
+    CONDA_INSTALL_EXTRA: "black>=20.8b1 flake8 pylint"
     PYTHON: '3.7'
 
   steps:

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
     - pytest
     - pytest-cov
     - coverage
-    - black
+    - black>=20.8b1
     - pylint
     - flake8
     - sphinx=2.2.1

--- a/examples/eql/harmonic_spherical.py
+++ b/examples/eql/harmonic_spherical.py
@@ -28,7 +28,8 @@ data = hm.datasets.fetch_south_africa_gravity()
 # aliasing effects.
 blocked_mean = vd.BlockReduce(np.mean, spacing=0.2, drop_coords=False)
 (longitude, latitude, elevation), gravity_data = blocked_mean.filter(
-    (data.longitude, data.latitude, data.elevation), data.gravity,
+    (data.longitude, data.latitude, data.elevation),
+    data.gravity,
 )
 
 # Compute gravity disturbance by removing the gravity of normal Earth
@@ -56,7 +57,9 @@ print("R² score:", eql.score(coordinates, gravity_disturbance))
 # maximum radius of the data, we're effectively upward-continuing the data.
 # The grid will be defined in spherical coordinates.
 grid = eql.grid(
-    spacing=0.2, extra_coords=coordinates[-1].max(), data_names=["gravity_disturbance"],
+    spacing=0.2,
+    extra_coords=coordinates[-1].max(),
+    data_names=["gravity_disturbance"],
 )
 
 # Mask grid points too far from data points
@@ -71,7 +74,12 @@ maxabs = vd.maxabs(gravity_disturbance, grid.gravity_disturbance.values)
 region = vd.get_region(coordinates)
 
 # Plot observed and gridded gravity disturbance
-fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(10, 5), sharey=True,)
+fig, (ax1, ax2) = plt.subplots(
+    nrows=1,
+    ncols=2,
+    figsize=(10, 5),
+    sharey=True,
+)
 
 tmp = ax1.scatter(
     longitude,

--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -93,7 +93,10 @@ class EQLHarmonic(vdb.BaseGridder):
     extra_coords_name = "upward"
 
     def __init__(
-        self, damping=None, points=None, relative_depth=500,
+        self,
+        damping=None,
+        points=None,
+        relative_depth=500,
     ):
         self.damping = damping
         self.points = points
@@ -294,7 +297,10 @@ class EQLHarmonicSpherical(EQLHarmonic):
     extra_coords_name = "radius"
 
     def __init__(
-        self, damping=None, points=None, relative_depth=500,
+        self,
+        damping=None,
+        points=None,
+        relative_depth=500,
     ):
         super().__init__(damping=damping, points=points, relative_depth=relative_depth)
         # Define Green's function for spherical coordinates


### PR DESCRIPTION
After version 19, black changed the formatting slightly in a few files.
This updates the format and sets a minimum version of black in the
development environment and the CI.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
