### PR TITLE
Fetch a sample data before testing locate() function

### DIFF
--- a/harmonica/tests/test_sample_data.py
+++ b/harmonica/tests/test_sample_data.py
@@ -17,6 +17,9 @@ from ..datasets.sample_data import (
 
 def test_datasets_locate():
     "Make sure the data cache location has the right package name"
+    # Fetch a dataset first to make sure that the cache folder exists. Since
+    # Pooch 1.1.1 the cache isn't created until a download is requested.
+    fetch_gravity_earth()
     path = locate()
     assert os.path.exists(path)
     # This is the most we can check in a platform independent way without


### PR DESCRIPTION
After Pooch v1.1.1 the cache directory where all sample data are downloaded to
is created when a dataset is fetched and not on initialization as before. This
makes the `test_datasets_locate()` to fail on a fresh installation of Harmonica
(where no dataset has been downloaded yet). The solution proposed in Verde
(https://github.com/fatiando/verde/pull/271) is to fetch one dataset before
running the `locate()` function.


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
