### PR TITLE
Cancel previous runs of GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       # Cancel any previous run of the test job
       # We pin the commit hash corresponding to v0.5.0, and not pinning the tag
-      # because we are giving full access through the gitub.token.
+      # because we are giving full access through the github.token.
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@148d9a848c6acaf90a3ec30bc5062f646f8a4163
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,14 @@ jobs:
       PYTHON: ${{ matrix.python }}
 
     steps:
+      # Cancel any previous run of the test job
+      # We pin the commit hash corresponding to v0.5.0, and not pinning the tag
+      # because we are giving full access through the gitub.token.
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@148d9a848c6acaf90a3ec30bc5062f646f8a4163
+        with:
+          access_token: ${{ github.token }}
+
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-
   #############################################################################
   # Publish built wheels and source archives to PyPI and test PyPI
   pypi:
@@ -33,7 +32,6 @@ jobs:
     if: github.repository == 'fatiando/harmonica'
 
     steps:
-
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install requirements
         run: python -m pip install setuptools twine wheel
@@ -110,7 +108,6 @@ jobs:
       PYTHON: 3.8
 
     steps:
-
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,6 @@ on:
 
 ###############################################################################
 jobs:
-
   black:
     name: black [format]
     runs-on: ubuntu-latest
@@ -29,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install requirements
         run: pip install black>=20.8b1
@@ -52,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install requirements
         run: pip install flake8
@@ -75,7 +74,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install requirements
         run: pip install pylint==2.4.*


### PR DESCRIPTION
Add [cancel-workflow-action](https://github.com/marketplace/actions/cancel-workflow-action) to the `test` job on `continuous_integration.py` workflow so any previous job that is still being run gets cancelled, so we focus the CIs resources on the last push.


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
