### PR TITLE
Parallelize EQLs predictions and Jacobian build

### DIFF
--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -5,19 +5,19 @@ from warnings import warn
 from numba import jit, prange
 
 
-@jit(nopython=True)
+@jit(nopython=True, parallel=True)
 def jacobian_numba(coordinates, points, jac, greens_function):
     """
     Calculate the Jacobian matrix using numba to speed things up.
 
-    It works both for Cartesian and spherical coordiantes.
-    We need to pass the corresponding Green's function through the
-    ``greens_function`` argument.
+    It works both for Cartesian and spherical coordiantes. We need to pass the
+    corresponding Green's function through the ``greens_function`` argument.
+    The Jacobian is built in parallel in order to reduce the computation time.
     """
     east, north, upward = coordinates[:]
     point_east, point_north, point_upward = points[:]
-    for i in range(east.size):
-        for j in range(point_east.size):
+    for i in prange(east.size):
+        for j in prange(point_east.size):
             jac[i, j] = greens_function(
                 east[i],
                 north[i],

--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -17,7 +17,7 @@ def jacobian_numba(coordinates, points, jac, greens_function):
     east, north, upward = coordinates[:]
     point_east, point_north, point_upward = points[:]
     for i in prange(east.size):
-        for j in prange(point_east.size):
+        for j in range(point_east.size):
             jac[i, j] = greens_function(
                 east[i],
                 north[i],
@@ -42,7 +42,7 @@ def predict_numba(
     east, north, upward = coordinates[:]
     point_east, point_north, point_upward = points[:]
     for i in prange(east.size):
-        for j in prange(point_east.size):
+        for j in range(point_east.size):
             result[i] += coeffs[j] * greens_function(
                 east[i],
                 north[i],

--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -2,7 +2,7 @@
 Utility functions for equivalent layer gridders
 """
 from warnings import warn
-from numba import jit
+from numba import jit, prange
 
 
 @jit(nopython=True)
@@ -28,19 +28,21 @@ def jacobian_numba(coordinates, points, jac, greens_function):
             )
 
 
-@jit(nopython=True)
-def predict_numba(coordinates, points, coeffs, result, greens_function):
+@jit(nopython=True, parallel=True)
+def predict_numba(
+    coordinates, points, coeffs, result, greens_function
+):  # pylint: disable=not-an-iterable
     """
     Calculate the predicted data using numba for speeding things up.
 
-    It works both for Cartesian and spherical coordiantes.
-    We need to pass the corresponding Green's function through the
-    ``greens_function`` argument.
+    It works both for Cartesian and spherical coordiantes. We need to pass the
+    corresponding Green's function through the ``greens_function`` argument.
+    The prediction is run in parallel in order to reduce the computation time.
     """
     east, north, upward = coordinates[:]
     point_east, point_north, point_upward = points[:]
-    for i in range(east.size):
-        for j in range(point_east.size):
+    for i in prange(east.size):
+        for j in prange(point_east.size):
             result[i] += coeffs[j] * greens_function(
                 east[i],
                 north[i],


### PR DESCRIPTION
Parallelize the build of the Jacobian matrix and the prediction step on
equivalent layer gridders through `numba.prange` iterators. This enables the
`fit` and `predict` methods to use all the available CPUs, greatly reducing the
computational time. The `prange` is only applied to the outer loops for each
task, i.e. distributing computation points between CPUs, but leaving the
iteration through the sources on single ones.


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
