### PR TITLE
Optimize forward models

### DIFF
--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -12,9 +12,7 @@ from numba import jit, prange
 
 
 @jit(nopython=True, parallel=True)
-def jacobian_numba(
-    coordinates, points, jac, greens_function
-):  # pylint: disable=not-an-iterable
+def jacobian_numba(coordinates, points, jac, greens_function):
     """
     Calculate the Jacobian matrix using numba to speed things up.
 

--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -6,7 +6,9 @@ from numba import jit, prange
 
 
 @jit(nopython=True, parallel=True)
-def jacobian_numba(coordinates, points, jac, greens_function):
+def jacobian_numba(
+    coordinates, points, jac, greens_function
+):  # pylint: disable=not-an-iterable
     """
     Calculate the Jacobian matrix using numba to speed things up.
 

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -240,11 +240,16 @@ def get_kernel(coordinate_system, field):
         "spherical": {
             "potential": kernel_potential_spherical,
             "g_z": kernel_g_z_spherical,
+            "g_northing": None,
+            "g_easting": None,
         },
     }
     if field not in kernels[coordinate_system]:
         raise ValueError("Gravitational field {} not recognized".format(field))
-    return kernels[coordinate_system][field]
+    kernel = kernels[coordinate_system][field]
+    if kernel is None:
+        raise NotImplementedError
+    return kernel
 
 
 @jit(nopython=True)

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -2,7 +2,7 @@
 Forward modelling for point masses
 """
 import numpy as np
-from numba import jit
+from numba import jit, prange
 
 from ..constants import GRAVITATIONAL_CONST
 from .utils import check_coordinate_system, distance_cartesian, distance_spherical_core
@@ -214,7 +214,7 @@ def point_mass_gravity(
     return result.reshape(cast.shape)
 
 
-@jit(nopython=True)
+@jit(nopython=True, parallel=True)
 def jit_point_mass_cartesian(
     easting, northing, upward, easting_p, northing_p, upward_p, masses, out, kernel
 ):  # pylint: disable=invalid-name
@@ -237,7 +237,7 @@ def jit_point_mass_cartesian(
         Kernel function that will be used to compute the gravitational field on
         the computation points.
     """
-    for l in range(easting.size):
+    for l in prange(easting.size):
         for m in range(easting_p.size):
             out[l] += masses[m] * kernel(
                 easting[l],
@@ -305,7 +305,7 @@ def kernel_g_easting_cartesian(
     return -(easting - easting_p) / distance ** 3
 
 
-@jit(nopython=True)
+@jit(nopython=True, parallel=True)
 def jit_point_mass_spherical(
     longitude, latitude, radius, longitude_p, latitude_p, radius_p, masses, out, kernel
 ):  # pylint: disable=invalid-name
@@ -341,7 +341,7 @@ def jit_point_mass_spherical(
     cosphi_p = np.cos(latitude_p)
     sinphi_p = np.sin(latitude_p)
     # Compute gravitational field
-    for l in range(longitude.size):
+    for l in prange(longitude.size):
         for m in range(longitude_p.size):
             out[l] += masses[m] * kernel(
                 longitude[l],

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -168,7 +168,7 @@ def point_mass_gravity(
         point masses.
         Available coordinates systems: ``cartesian``, ``spherical``.
         Default ``cartesian``.
-    parallel : bool
+    parallel : bool (optional)
         If True the computations will run in parallel using Numba built-in
         parallelization. If False, the forward model will run on a single core.
         Might be useful to disable parallelization if the forward model is run

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -217,7 +217,7 @@ def point_mass_gravity(
 @jit(nopython=True, parallel=True)
 def jit_point_mass_cartesian(
     easting, northing, upward, easting_p, northing_p, upward_p, masses, out, kernel
-):  # pylint: disable=invalid-name
+):  # pylint: disable=invalid-name,not-an-iterable
     """
     Compute gravitational field of point masses in Cartesian coordinates
 
@@ -308,7 +308,7 @@ def kernel_g_easting_cartesian(
 @jit(nopython=True, parallel=True)
 def jit_point_mass_spherical(
     longitude, latitude, radius, longitude_p, latitude_p, radius_p, masses, out, kernel
-):  # pylint: disable=invalid-name
+):  # pylint: disable=invalid-name,not-an-iterable
     """
     Compute gravitational field of point masses in spherical coordinates
 

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -204,7 +204,7 @@ def point_mass_gravity(
         },
     }
     # Sanity checks for coordinate_system and field
-    check_coordinate_system(coordinate_system)
+    check_coordinate_system(coordinate_system, valid_coord_systems=("cartesian", "spherical"))
     if field not in kernels[coordinate_system]:
         raise ValueError("Gravitational field {} not recognized".format(field))
     # Figure out the shape and size of the output array

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -220,7 +220,7 @@ def dispatcher(coordinate_system, parallel):
         },
         "spherical": {
             True: point_mass_spherical_parallel,
-            False: point_mass_cartesian_serial,
+            False: point_mass_spherical_serial,
         },
     }
     return dispatchers[coordinate_system][parallel]

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -251,7 +251,7 @@ def get_kernel(coordinate_system, field):
         },
     }
     if field not in kernels[coordinate_system]:
-        raise ValueError("Gravitational field {} not recognized".format(field))
+        raise ValueError("Gravitational field '{}' not recognized".format(field))
     kernel = kernels[coordinate_system][field]
     if kernel is None:
         raise NotImplementedError

--- a/harmonica/forward/prism.py
+++ b/harmonica/forward/prism.py
@@ -164,7 +164,7 @@ def _check_prisms(prisms):
 @jit(nopython=True, parallel=True)
 def jit_prism_gravity(
     coordinates, prisms, density, kernel, out
-):  # pylint: disable=invalid-name
+):  # pylint: disable=invalid-name,not-an-iterable
     """
     Compute gravitational field of prisms on computations points
 

--- a/harmonica/forward/prism.py
+++ b/harmonica/forward/prism.py
@@ -2,7 +2,7 @@
 Forward modelling for prisms
 """
 import numpy as np
-from numba import jit
+from numba import jit, prange
 
 from ..constants import GRAVITATIONAL_CONST
 
@@ -161,7 +161,7 @@ def _check_prisms(prisms):
         raise ValueError(err_msg)
 
 
-@jit(nopython=True)
+@jit(nopython=True, parallel=True)
 def jit_prism_gravity(
     coordinates, prisms, density, kernel, out
 ):  # pylint: disable=invalid-name
@@ -189,7 +189,7 @@ def jit_prism_gravity(
         Must have the same size as the arrays contained on ``coordinates``.
     """
     # Iterate over computation points and prisms
-    for l in range(coordinates[0].size):
+    for l in prange(coordinates[0].size):
         for m in range(prisms.shape[0]):
             # Iterate over the prism boundaries to compute the result of the
             # integration (see Nagy et al., 2000)

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -198,7 +198,7 @@ def tesseroid_gravity(
     return result.reshape(cast.shape)
 
 
-@jit(nopython=True, parallel=True)
+@jit(nopython=True)
 def jit_tesseroid_gravity(
     coordinates,
     tesseroids,

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -282,7 +282,7 @@ def jit_tesseroid_gravity(
                 small_tesseroids,
                 radial_discretization,
             )
-            # Compute effect of the tesseroid though GLQ
+            # Compute effect of the tesseroid through GLQ
             for tess_index in range(n_splits):
                 tesseroid = small_tesseroids[tess_index, :]
                 result[l] += gauss_legendre_quadrature(

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -363,18 +363,19 @@ def gauss_legendre_quadrature(
     # are evaluated)
     result = 0.0
     for j, lat_node in enumerate(lat_nodes):
-        # Get the latitudes of the point masses
+        # Get the latitudes of the point mass
         latitude_p = np.radians(0.5 * (n - s) * lat_node + 0.5 * (n + s))
         cosphi_p = np.cos(latitude_p)
         sinphi_p = np.sin(latitude_p)
         for k, rad_node in enumerate(rad_nodes):
-            # Get the radii of the point masses
+            # Get the radii of the point mass
             radius_p = 0.5 * (top - bottom) * rad_node + 0.5 * (top + bottom)
-            # Get kappa constant and the mass of the point mass
+            # Get kappa constant for the point mass
             kappa = radius_p ** 2 * cosphi_p
             for i, lon_node in enumerate(lon_nodes):
-                # Get the longitudes of the point masses
+                # Get the longitudes of the point mass
                 longitude_p = np.radians(0.5 * (e - w) * lon_node + 0.5 * (e + w))
+                # Compute the mass of the point mass
                 mass = (
                     density
                     * a_factor

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -300,7 +300,7 @@ def gauss_legendre_quadrature(
     glq_nodes,
     glq_weights,
     kernel,
-):
+):  # pylint: disable=too-many-locals
     r"""
     Compute the effect of a tesseroid on a single observation point through GLQ
 
@@ -343,7 +343,7 @@ def gauss_legendre_quadrature(
     # Get tesseroid boundaries
     w, e, s, n, bottom, top = tesseroid[:]
     # Calculate the A factor for the tesseroid
-    A_factor = 1 / 8 * np.radians(e - w) * np.radians(n - s) * (top - bottom)
+    a_factor = 1 / 8 * np.radians(e - w) * np.radians(n - s) * (top - bottom)
     # Unpack nodes and weights
     lon_nodes, lat_nodes, rad_nodes = glq_nodes[:]
     lon_weights, lat_weights, rad_weights = glq_weights[:]
@@ -362,7 +362,7 @@ def gauss_legendre_quadrature(
                 kappa = radius_p ** 2 * cosphi_p
                 mass = (
                     density
-                    * A_factor
+                    * a_factor
                     * kappa
                     * lon_weights[i]
                     * lat_weights[j]

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -351,18 +351,24 @@ def gauss_legendre_quadrature(
     lon_nodes, lat_nodes, rad_nodes = glq_nodes[:]
     lon_weights, lat_weights, rad_weights = glq_weights[:]
     # Compute effect of the tesseroid on the observation point
+    # by iterating over the location of the point masses
+    # (move the iteration along the longitudinal nodes to the bottom for
+    # optimization: reduce the number of times that the trigonometric functions
+    # are evaluated)
     result = 0.0
-    for i, lon_node in enumerate(lon_nodes):
-        for j, lat_node in enumerate(lat_nodes):
-            for k, rad_node in enumerate(rad_nodes):
-                # Get coordinates of the point mass
+    for j, lat_node in enumerate(lat_nodes):
+        # Get the latitudes of the point masses
+        latitude_p = np.radians(0.5 * (n - s) * lat_node + 0.5 * (n + s))
+        cosphi_p = np.cos(latitude_p)
+        sinphi_p = np.sin(latitude_p)
+        for k, rad_node in enumerate(rad_nodes):
+            # Get the radii of the point masses
+            radius_p = 0.5 * (top - bottom) * rad_node + 0.5 * (top + bottom)
+            # Get kappa constant and the mass of the point mass
+            kappa = radius_p ** 2 * cosphi_p
+            for i, lon_node in enumerate(lon_nodes):
+                # Get the longitudes of the point masses
                 longitude_p = np.radians(0.5 * (e - w) * lon_node + 0.5 * (e + w))
-                latitude_p = np.radians(0.5 * (n - s) * lat_node + 0.5 * (n + s))
-                radius_p = 0.5 * (top - bottom) * rad_node + 0.5 * (top + bottom)
-                cosphi_p = np.cos(latitude_p)
-                sinphi_p = np.sin(latitude_p)
-                # Get kappa constant and the mass of the point mass
-                kappa = radius_p ** 2 * cosphi_p
                 mass = (
                     density
                     * a_factor

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -259,6 +259,8 @@ def jit_tesseroid_gravity(
     kernel : func
         Kernel function for the gravitational field of point masses.
     """
+    # Get coordinates of the observation points
+    # and precompute trigonometric functions
     longitude, latitude, radius = coordinates[:]
     longitude_rad = np.radians(longitude)
     cosphi = np.cos(np.radians(latitude))
@@ -274,6 +276,7 @@ def jit_tesseroid_gravity(
                 small_tesseroids,
                 radial_discretization,
             )
+            # Compute effect of the tesseroid though GLQ
             for tess_index in range(n_splits):
                 tesseroid = small_tesseroids[tess_index, :]
                 result[l] += gauss_legendre_quadrature(

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -363,17 +363,17 @@ def gauss_legendre_quadrature(
     # are evaluated)
     result = 0.0
     for j, lat_node in enumerate(lat_nodes):
-        # Get the latitudes of the point mass
+        # Get the latitude of the point mass
         latitude_p = np.radians(0.5 * (n - s) * lat_node + 0.5 * (n + s))
         cosphi_p = np.cos(latitude_p)
         sinphi_p = np.sin(latitude_p)
         for k, rad_node in enumerate(rad_nodes):
-            # Get the radii of the point mass
+            # Get the radius of the point mass
             radius_p = 0.5 * (top - bottom) * rad_node + 0.5 * (top + bottom)
             # Get kappa constant for the point mass
             kappa = radius_p ** 2 * cosphi_p
             for i, lon_node in enumerate(lon_nodes):
-                # Get the longitudes of the point mass
+                # Get the longitude of the point mass
                 longitude_p = np.radians(0.5 * (e - w) * lon_node + 0.5 * (e + w))
                 # Compute the mass of the point mass
                 mass = (

--- a/harmonica/tests/test_point_mass.py
+++ b/harmonica/tests/test_point_mass.py
@@ -28,6 +28,25 @@ def test_invalid_coordinate_system():
         )
 
 
+def test_not_implemented_field():
+    """
+    Check if NotImplementedError is raised after asking a non-implemented field
+    """
+    coordinates = [0.0, 0.0, 0.0]
+    point_mass = [0.0, 0.0, 0.0]
+    mass = 1.0
+    coordinate_system = "spherical"
+    for field in ("g_northing", "g_easting"):
+        with pytest.raises(NotImplementedError):
+            point_mass_gravity(
+                coordinates,
+                point_mass,
+                mass,
+                field,
+                coordinate_system,
+            )
+
+
 def test_invalid_field():
     "Check if an invalid gravitational field is passed as argument"
     coordinates = [0.0, 0.0, 0.0]


### PR DESCRIPTION
Parallelize the outer loops of `prism_gravity` and `point_mass_gravity`. Add an
optional `parallel` argument to `prism_gravity` and `point_mass_gravity` to run
them in parallel or in serial at will. Refactor and optimize tesseroids forward
model: avoid defining a set of point masses to compute their effect, instead
compute results in runtime. Simplify its code, reduce memory consumption and
prevent tesseroid forward model from using `jit_point_mass_spherical` function
which has been parallelized, but we don't want to use its parallel version when
computing GLQ on tesseroids forward model.

Fixes #204 

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
