### PR TITLE
Add parallel flag to EQLs

### DIFF
--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -11,6 +11,15 @@ from warnings import warn
 import numba
 
 
+def pop_extra_coords(kwargs):
+    """
+    Remove extra_coords from kwargs
+    """
+    if "extra_coords" in kwargs:
+        warn("EQL gridder will ignore extra_coords: {}.".format(kwargs["extra_coords"]))
+        kwargs.pop("extra_coords")
+
+
 def jacobian(
     coordinates, points, jac, greens_function
 ):  # pylint: disable=not-an-iterable
@@ -61,16 +70,8 @@ def predict(
             )
 
 
+# pylint: disable=invalid-name
 predict_numba_serial = numba.jit(nopython=True)(predict)
 predict_numba_parallel = numba.jit(nopython=True, parallel=True)(predict)
 jacobian_numba_serial = numba.jit(nopython=True)(jacobian)
 jacobian_numba_parallel = numba.jit(nopython=True, parallel=True)(jacobian)
-
-
-def pop_extra_coords(kwargs):
-    """
-    Remove extra_coords from kwargs
-    """
-    if "extra_coords" in kwargs:
-        warn("EQL gridder will ignore extra_coords: {}.".format(kwargs["extra_coords"]))
-        kwargs.pop("extra_coords")

--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -8,7 +8,7 @@
 Utility functions for equivalent layer gridders
 """
 from warnings import warn
-import numba
+from numba import jit, prange
 
 
 def pop_extra_coords(kwargs):
@@ -33,7 +33,7 @@ def jacobian(
     """
     east, north, upward = coordinates[:]
     point_east, point_north, point_upward = points[:]
-    for i in numba.prange(east.size):
+    for i in prange(east.size):
         for j in range(point_east.size):
             jac[i, j] = greens_function(
                 east[i],
@@ -58,7 +58,7 @@ def predict(
     """
     east, north, upward = coordinates[:]
     point_east, point_north, point_upward = points[:]
-    for i in numba.prange(east.size):
+    for i in prange(east.size):
         for j in range(point_east.size):
             result[i] += coeffs[j] * greens_function(
                 east[i],
@@ -71,7 +71,7 @@ def predict(
 
 
 # pylint: disable=invalid-name
-predict_numba_serial = numba.jit(nopython=True)(predict)
-predict_numba_parallel = numba.jit(nopython=True, parallel=True)(predict)
-jacobian_numba_serial = numba.jit(nopython=True)(jacobian)
-jacobian_numba_parallel = numba.jit(nopython=True, parallel=True)(jacobian)
+predict_numba_serial = jit(nopython=True)(predict)
+predict_numba_parallel = jit(nopython=True, parallel=True)(predict)
+jacobian_numba_serial = jit(nopython=True)(jacobian)
+jacobian_numba_parallel = jit(nopython=True, parallel=True)(jacobian)


### PR DESCRIPTION
Add the option to enable/disable parallelization on EQLs through a new
`parallel` attribute that can be set on initialization or anytime.
Add dispatcher functions to choose between the regular version or the
parallized version of the `predict_numba` and `jacobian_numba` functions.


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
