### PR TITLE
Update setup-miniconda Action to v2.0.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,8 +87,8 @@ jobs:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('requirements*.txt') }}
 
-      - name: Setup miniconda
-        uses: goanpeca/setup-miniconda@v1
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.1
         with:
           python-version: ${{ matrix.python }}
           miniconda-version: "latest"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,8 +130,8 @@ jobs:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ env.PYTHON }}-${{ hashFiles('requirements*.txt') }}
 
-      - name: Setup miniconda
-        uses: goanpeca/setup-miniconda@v1
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.1
         with:
           python-version: ${{ env.PYTHON }}
           miniconda-version: "latest"


### PR DESCRIPTION
Update `setup-miniconda` GitHub Action to `v2.0.1` and use the one
released by `conda-incubator` instead of one of its forks.
