### PR TITLE
Automatically check for license notice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ PROJECT=harmonica
 TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 NUMBATEST_ARGS=--doctest-modules -v --pyargs -m use_numba
-LINT_FILES=setup.py $(PROJECT)
-BLACK_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py
-FLAKE8_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py
+LINT_FILES=setup.py $(PROJECT) license_notice.py
+BLACK_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py license_notice.py
+FLAKE8_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py license_notice.py
 
 help:
 	@echo "Commands:"
@@ -36,13 +36,19 @@ test_numba:
 	cd $(TESTDIR); NUMBA_DISABLE_JIT=0 MPLBACKEND='agg' pytest $(NUMBATEST_ARGS) $(PROJECT)
 	rm -rvf $(TESTDIR)
 
-format:
+format: license
 	black $(BLACK_FILES)
 
-check: black-check flake8
+check: black-check flake8 license-check
 
 black-check:
 	black --check $(BLACK_FILES)
+
+license:
+	python license_notice.py
+
+license-check:
+	python license_notice.py --check
 
 flake8:
 	flake8 $(FLAKE8_FILES)

--- a/license_notice.py
+++ b/license_notice.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2018 The Harmonica Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
 """
 Add license notice to every source file if not present
 """
@@ -16,6 +19,9 @@ NOTICE = f"""
 # Copyright (c) {YEAR} The {PROJECT.title()} Developers.
 # Distributed under the terms of the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
 """.strip()
 CHECK_HELP = """
 Don't write the files, just return the status. Return code 0 means

--- a/license_notice.py
+++ b/license_notice.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2018 The Harmonica Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Add license notice to every source file if not present
+"""
+import sys
+from pathlib import Path
+from argparse import ArgumentParser
+from pathspec import PathSpec
+
+
+PROJECT = "harmonica"
+YEAR = "2018"
+NOTICE = f"""
+# Copyright (c) {YEAR} The {PROJECT.title()} Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+""".strip()
+CHECK_HELP = """
+Don't write the files, just return the status. Return code 0 means
+nothing would change. Return code 1 means some files lacks the license notice.
+"""
+
+
+def get_gitignore(root):
+    """
+    Return a PathSpec matching gitignore content if present.
+
+    This function is a modified version of the one present in Black
+    (https://github.com/psf/black) available under MIT License.
+    """
+    gitignore = root / ".gitignore"
+    lines = []
+    if gitignore.is_file():
+        with gitignore.open() as gi_file:
+            lines = gi_file.readlines()
+    return PathSpec.from_lines("gitwildmatch", lines)
+
+
+def main():
+    """
+    Add license notice to every source file if not present or just check
+    """
+    # Create option parser
+    parser = ArgumentParser(
+        description=" Add license notice to every source file if not present."
+    )
+    parser.add_argument(
+        "--check", action="store_true", dest="check", default=False, help=CHECK_HELP
+    )
+    args = parser.parse_args()
+
+    gitignore = get_gitignore(Path("."))
+
+    python_files = [
+        path
+        for path in Path(".").glob("**/*.py")
+        if not str(path).startswith(".")
+        if not gitignore.match_file(path)
+    ]
+
+    missing_notice_files = []
+    for pyfile in python_files:
+        code = pyfile.read_text()
+        if not code.startswith(NOTICE):
+            missing_notice_files.append(pyfile)
+
+    if args.check:
+        if missing_notice_files:
+            print("License notice is missing in some source files! 💔")
+            for pyfile in missing_notice_files:
+                print(f"  {pyfile}")
+            sys.exit(1)
+        else:
+            print("All source files have the license notice! 🎉")
+            sys.exit(0)
+    else:
+        print("Successfully added license notice to:")
+        for pyfile in missing_notice_files:
+            code = pyfile.read_text()
+            pyfile.write_text("\n".join([NOTICE, code]))
+            print(f"  {pyfile}")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a new `license_notice.py` script that checks if the license notice is
present on every source file or adds it to them. Source files are `.py` files
not ignored on `.gitignore`. Run the file on the `check` and `format` targets
on Makefile. Lint and style check the new `license_notice.py` file.

Related to fatiando/maintenance#12



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
