### PR TITLE
Fix typos on coordinates

### DIFF
--- a/harmonica/equivalent_layer/utils.py
+++ b/harmonica/equivalent_layer/utils.py
@@ -16,7 +16,7 @@ def jacobian_numba(coordinates, points, jac, greens_function):
     """
     Calculate the Jacobian matrix using numba to speed things up.
 
-    It works both for Cartesian and spherical coordiantes. We need to pass the
+    It works both for Cartesian and spherical coordinates. We need to pass the
     corresponding Green's function through the ``greens_function`` argument.
     The Jacobian is built in parallel in order to reduce the computation time.
     """
@@ -41,7 +41,7 @@ def predict_numba(
     """
     Calculate the predicted data using numba for speeding things up.
 
-    It works both for Cartesian and spherical coordiantes. We need to pass the
+    It works both for Cartesian and spherical coordinates. We need to pass the
     corresponding Green's function through the ``greens_function`` argument.
     The prediction is run in parallel in order to reduce the computation time.
     """

--- a/harmonica/forward/point_mass.py
+++ b/harmonica/forward/point_mass.py
@@ -131,7 +131,7 @@ def point_mass_gravity(
     coordinates : list or array
         List or array containing the coordinates of computation points in the
         following order: ``easting``, ``northing`` and ``upward`` (if
-        coordinates given in Cartesian coordiantes), or ``longitude``,
+        coordinates given in Cartesian coordinates), or ``longitude``,
         ``latitude`` and ``radius`` (if given on a spherical geocentric
         coordinate system).
         All ``easting``, ``northing`` and ``upward`` should be in meters.
@@ -140,7 +140,7 @@ def point_mass_gravity(
     points : list or array
         List or array containing the coordinates of the point masses in the
         following order: ``easting``, ``northing`` and ``upward`` (if
-        coordinates given in Cartesian coordiantes), or ``longitude``,
+        coordinates given in Cartesian coordinates), or ``longitude``,
         ``latitude`` and ``radius`` (if given on a spherical geocentric
         coordinate system).
         All ``easting``, ``northing`` and ``upward`` should be in meters.

--- a/harmonica/tests/test_eql_harmonic.py
+++ b/harmonica/tests/test_eql_harmonic.py
@@ -45,7 +45,7 @@ def test_pop_extra_coords():
 def test_eql_harmonic_cartesian():
     """
     Check that predictions are reasonable when interpolating from one grid to
-    a denser grid. Use Cartesian coordiantes.
+    a denser grid. Use Cartesian coordinates.
     """
     region = (-3e3, -1e3, 5e3, 7e3)
     # Build synthetic point masses
@@ -196,7 +196,7 @@ def test_eql_harmonic_jacobian_cartesian():
 def test_eql_harmonic_spherical():
     """
     Check that predictions are reasonable when interpolating from one grid to
-    a denser grid. Use spherical coordiantes.
+    a denser grid. Use spherical coordinates.
     """
     region = (-70, -60, -40, -30)
     radius = 6400e3

--- a/harmonica/tests/test_forward_utils.py
+++ b/harmonica/tests/test_forward_utils.py
@@ -66,7 +66,7 @@ def test_geodetic_distance_vs_spherical():
     point_b = (-71.2, -33.3, 1025)
     # Compute distance using closed-form formula
     dist = distance(point_a, point_b, coordinate_system="geodetic", ellipsoid=ellipsoid)
-    # Convert points to spherical coordiantes
+    # Convert points to spherical coordinates
     point_a_sph = ellipsoid.geodetic_to_spherical(*point_a)
     point_b_sph = ellipsoid.geodetic_to_spherical(*point_b)
     # Compute distance using these converted points


### PR DESCRIPTION
Replace `coordiantes` for `coordinates`.




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
