### PR TITLE
Fix wrong version numbers for PyPI releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,13 +60,16 @@ jobs:
       - name: List installed packages
         run: python -m pip freeze
 
-      - name: Build source and wheel distributions
+      - name: Don't use local version numbers for TestPyPI uploads
+        if: github.event_name != 'release'
         run: |
           # Change setuptools-scm local_scheme to "no-local-version" so the
           # local part of the version isn't included, making the version string
           # compatible with Test PyPI.
           sed --in-place "s/node-and-date/no-local-version/g" setup.py
-          python setup.py sdist bdist_wheel
+
+      - name: Build source and wheel distributions
+        run: python setup.py sdist bdist_wheel
           echo ""
           echo "Generated files:"
           ls -lh dist/


### PR DESCRIPTION
For test releases to TestPyPI we have to edit the setuptools_scm
configuration to produce valid version numbers. But it turns out that
this breaks the number for actual releases. To fix it, only edit the
configuration on non-release builds.

Issue raised on https://github.com/fatiando/verde/pull/317


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
