### PR TITLE
Unpin Sphinx

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - black>=20.8b1
   - pylint
   - flake8
-  - sphinx=2.2.1
+  - sphinx
   - sphinx_rtd_theme=0.4.3
   - sphinx-gallery
   - numpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-cov
 coverage
 pylint
 flake8
-sphinx=2.2.1
+sphinx
 sphinx_rtd_theme=0.4.3
 sphinx-gallery
 numpydoc


### PR DESCRIPTION
Unpin `sphinx` from `environment.yml` and `requirements-dev.txt`.
Solve the toctree issue where the p tags were not getting a `caption`
class.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
