### PR TITLE
Explicitly use the class dims on EQLs

### DIFF
--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -306,6 +306,9 @@ class EQLHarmonic(vdb.BaseGridder):
 
         # Ignore extra_coords if passed
         pop_extra_coords(kwargs)
+        # Explicitly set dims
+        if dims is None:
+            dims = self.dims
         # Grid data
         grid = super().grid(
             region=region,
@@ -424,6 +427,9 @@ class EQLHarmonic(vdb.BaseGridder):
 
         # Ignore extra_coords if passed
         pop_extra_coords(kwargs)
+        # Explicitly set dims
+        if dims is None:
+            dims = self.dims
         # Create profile points and predict
         table = super().profile(
             point1,

--- a/harmonica/equivalent_layer/harmonic_spherical.py
+++ b/harmonica/equivalent_layer/harmonic_spherical.py
@@ -300,6 +300,9 @@ class EQLHarmonicSpherical(vdb.BaseGridder):
 
         # Ignore extra_coords if passed
         pop_extra_coords(kwargs)
+        # Explicitly set dims
+        if dims is None:
+            dims = self.dims
         # Grid data
         # We always pass projection=None because that argument it's intended to
         # be used only with Cartesian gridders.

--- a/harmonica/tests/test_eql_harmonic.py
+++ b/harmonica/tests/test_eql_harmonic.py
@@ -260,6 +260,12 @@ def test_eql_harmonic_spherical():
     grid = eql.grid(upward, shape=shape, region=region)
     npt.assert_allclose(true, grid.scalars, rtol=1e-3)
 
+    # Test grid method with different dims
+    new_dims = ("foo", "bar")
+    eql.dims = new_dims
+    grid = eql.grid(upward, shape=shape, region=region)
+    assert grid.scalars.dims == new_dims
+
 
 def test_eql_harmonic_small_data_spherical():
     """
@@ -303,6 +309,12 @@ def test_eql_harmonic_small_data_spherical():
     # Test grid method
     grid = eql.grid(upward, shape=shape, region=region)
     npt.assert_allclose(true, grid.scalars, rtol=0.05)
+
+    # Test grid method with different dims
+    new_dims = ("foo", "bar")
+    eql.dims = new_dims
+    grid = eql.grid(upward, shape=shape, region=region)
+    assert grid.scalars.dims == new_dims
 
 
 def test_eql_harmonic_custom_points_spherical():


### PR DESCRIPTION
Override the `dims` parameter on the `grid` and `profile` methods in `EQLHarmonic` and `EQLHarmonicSpherical` to the `self.dims` class attribute if `dims` parameter is `None`.
This doesn't change the behavior of the methods because the `verde.base.BaseGridder` original methods already make use of the `_get_dims()` method. This changes only make it explicit in Harmonica classes.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
