### PR TITLE
Change order of dims in example of prism_layer

### DIFF
--- a/harmonica/forward/prism_layer.py
+++ b/harmonica/forward/prism_layer.py
@@ -93,7 +93,7 @@ def prism_layer(
     ... )
     >>> print(prisms) # doctest: +SKIP
     <xarray.Dataset>
-    Dimensions:   (easting: 5, northing: 4)
+    Dimensions:   (northing: 4, easting: 5)
     Coordinates:
       * easting   (easting) float64 0.0 2.5 5.0 7.5 10.0
       * northing  (northing) float64 2.0 4.0 6.0 8.0

--- a/harmonica/forward/prism_layer.py
+++ b/harmonica/forward/prism_layer.py
@@ -91,7 +91,7 @@ def prism_layer(
     ...     reference=0,
     ...     properties={"density": density},
     ... )
-    >>> print(prisms)
+    >>> print(prisms) # doctest: +SKIP
     <xarray.Dataset>
     Dimensions:   (easting: 5, northing: 4)
     Coordinates:


### PR DESCRIPTION
Change the order of the dimensions of `DataArrays` in the examples of
`prism_layer`, since `xarray v0.19.0` prints them in a different order. Tell
`pytest` to ignore the outputs of the `print` statements in the `prism_layer`
examples while running doctests.

Related to https://github.com/fatiando/verde/pull/329