### PR TITLE
Pass density as numpy array on prism_layer example

### DIFF
--- a/examples/forward/prisms_topo_gravity.py
+++ b/examples/forward/prisms_topo_gravity.py
@@ -47,7 +47,7 @@ prisms = hm.prism_layer(
     (south_africa_topo.easting, south_africa_topo.northing),
     surface=south_africa_topo.values,
     reference=0,
-    properties={"density": density},
+    properties={"density": density.values},
 )
 
 # Compute gravity field on a regular grid located at 4000m above the ellipsoid


### PR DESCRIPTION
Patch the `prism_layer` example so the density of the prisms is passed as
a Numpy array instead as a `DataArray`. This solves an `xarray` error when
building the docs. This is just a patch, although the problem must be solved
upstream in Verde.

Related to https://github.com/fatiando/verde/issues/330


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
