### PR TITLE
Remove unneeded line in prism_gravity example

### DIFF
--- a/harmonica/forward/prism.py
+++ b/harmonica/forward/prism.py
@@ -93,9 +93,6 @@ def prism_gravity(
     >>> prism = [-34, 5, -18, 14, -345, -146]
     >>> # Set prism density to 2670 kg/m³
     >>> density = 2670
-    >>> # Define a computation point above its center, at 30 meters above the
-    >>> # surface
-    >>> coordinates = (130, 75, 30)
     >>> # Define three computation points along the easting axe at 30m above
     >>> # the surface
     >>> coordinates = ([-40, 0, 40], [0, 0, 0], [30, 30, 30])


### PR DESCRIPTION
Removed a line in `prism_gravity` examples that creates a computation point that is not used afterwards.




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
