### PR TITLE
Replace bellow for below across docstrings

### DIFF
--- a/harmonica/equivalent_layer/harmonic.py
+++ b/harmonica/equivalent_layer/harmonic.py
@@ -71,8 +71,8 @@ class EQLHarmonic(vdb.BaseGridder):
         List containing the coordinates of the point sources used as the
         equivalent layer. Coordinates are assumed to be in the following order:
         (``easting``, ``northing``, ``upward``).
-        If None, will place one point source bellow each observation point at
-        a fixed relative depth bellow the observation point [Cooper2000]_.
+        If None, will place one point source below each observation point at
+        a fixed relative depth below the observation point [Cooper2000]_.
         Defaults to None.
     relative_depth : float
         Relative depth at which the point sources are placed beneath the

--- a/harmonica/equivalent_layer/harmonic_spherical.py
+++ b/harmonica/equivalent_layer/harmonic_spherical.py
@@ -73,8 +73,8 @@ class EQLHarmonicSpherical(vdb.BaseGridder):
         equivalent layer. Coordinates are assumed to be in the following order:
         (``longitude``, ``latitude``, ``radius``). Both ``longitude`` and
         ``latitude`` must be in degrees and ``radius`` in meters.
-        If None, will place one point source bellow each observation point at
-        a fixed relative depth bellow the observation point [Cooper2000]_.
+        If None, will place one point source below each observation point at
+        a fixed relative depth below the observation point [Cooper2000]_.
         Defaults to None.
     relative_depth : float
         Relative depth at which the point sources are placed beneath the

--- a/harmonica/tests/test_point_mass.py
+++ b/harmonica/tests/test_point_mass.py
@@ -358,7 +358,7 @@ def test_g_z_symmetry():
     # Define a single point mass
     point_mass = [1.1, 1.2, 1.3]
     masses = [2670]
-    # Define a pair of computation points above and bellow the point mass
+    # Define a pair of computation points above and below the point mass
     distance = 3.3
     easting = point_mass[0] * np.ones(2)
     northing = point_mass[1] * np.ones(2)
@@ -418,7 +418,7 @@ def test_g_z_sign():
     point_mass = [-10, 100.2, -300.7]
     mass = [2670]
     # Define three computation points located above, at the same depth and
-    # bellow the point mass
+    # below the point mass
     easting = np.zeros(3)
     northing = np.zeros(3) + 52.3
     upward = np.array([100.11, -300.7, -400])

--- a/harmonica/tests/test_prism.py
+++ b/harmonica/tests/test_prism.py
@@ -134,25 +134,25 @@ def test_g_z_symmetry_outside():
     prism we will define several set of computation points:
 
     A. Two points located on the vertical axis of the prism (``easting == 0``
-       and ``northing == 0``), one above and one bellow the prism at the same
+       and ``northing == 0``), one above and one below the prism at the same
        distance from its center.
     B. Four points located on the ``upward == 0`` plane around the prism
        distributed normally to its faces , i.e. only one of the horizontal
        coordinates will be nonzero.
     C. Same as points defined in B, but located on a plane above the prism.
-    D. Same as points defined in B, but located on a plane bellow the prism.
+    D. Same as points defined in B, but located on a plane below the prism.
     E. Same as points defined in B, but located on a plane slightly above the
        ``upward == 0`` plane.
-    F. Same as points defined in B, but located on a plane slightly bellow the
+    F. Same as points defined in B, but located on a plane slightly below the
        ``upward == 0`` plane.
     G. Four points located on the ``upward == 0`` plane around the prism
        distributed on the diagonal directions , i.e. both horizontal
        coordinates will be equal and nonzero.
     H. Same as points defined in G, but located on an plane above the prism.
-    I. Same as points defined in G, but located on an plane bellow the prism.
+    I. Same as points defined in G, but located on an plane below the prism.
     J. Same as points defined in G, but located on a plane slightly above the
        ``upward == 0`` plane.
-    K. Same as points defined in G, but located on a plane slightly bellow the
+    K. Same as points defined in G, but located on a plane slightly below the
        ``upward == 0`` plane.
 
     All computation points defined on the previous groups fall outside of the
@@ -200,7 +200,7 @@ def test_g_z_symmetry_outside():
         )
     # Check symmetries
     # Values on A must be opposite, and the value of g_z at the point above the
-    # prism must have the same sign as the density, while the one bellow should
+    # prism must have the same sign as the density, while the one below should
     # have the opposite
     npt.assert_allclose(results["A"][0], -results["A"][1])
     npt.assert_allclose(np.sign(results["A"][0]), -np.sign(density))
@@ -213,11 +213,11 @@ def test_g_z_symmetry_outside():
         npt.assert_allclose(0, results[group])
     # Values on C and D, E and F, H and I, J and K must be opposite
     # Moreover, the set of points that are above the prism must have the same
-    # sign as the density, while the ones bellow should have the opposite
-    for above, bellow in (("C", "D"), ("E", "F"), ("H", "I"), ("J", "K")):
-        npt.assert_allclose(results[above], -results[bellow])
+    # sign as the density, while the ones below should have the opposite
+    for above, below in (("C", "D"), ("E", "F"), ("H", "I"), ("J", "K")):
+        npt.assert_allclose(results[above], -results[below])
         npt.assert_allclose(np.sign(results[above]), np.sign(density))
-        npt.assert_allclose(np.sign(results[bellow]), -np.sign(density))
+        npt.assert_allclose(np.sign(results[below]), -np.sign(density))
 
 
 def test_g_z_symmetry_inside():
@@ -229,21 +229,21 @@ def test_g_z_symmetry_inside():
     several set of computation points:
 
     A. Two points located on the vertical axis of the prism (``easting == 0``
-       and ``northing == 0``), one above and one bellow the center of prism,
+       and ``northing == 0``), one above and one below the center of prism,
        but at the same distance from it.
     B. Four points located on the ``upward == 0`` plane around the prism
        distributed normally to its faces , i.e. only one of the horizontal
        coordinates will be nonzero.
     C. Same as points defined in B, but located on a plane above the
        ``upward == 0`` plane.
-    D. Same as points defined in B, but located on a plane bellow the
+    D. Same as points defined in B, but located on a plane below the
        ``upward == 0`` plane.
     E. Four points located on the ``upward == 0`` plane around the prism
        distributed on the diagonal directions , i.e. both horizontal
        coordinates will be equal and nonzero.
     F. Same as points defined in E, but located on a plane above the
        ``upward == 0`` plane.
-    G. Same as points defined in E, but located on a plane bellow the
+    G. Same as points defined in E, but located on a plane below the
        ``upward == 0`` plane.
 
     All computation points defined on the previous groups fall outside of the
@@ -282,7 +282,7 @@ def test_g_z_symmetry_inside():
     # Check symmetries
     # Values on A must be opposite, and the value of g_z at the point above the
     # center of the prism must have the same sign as the density, while the one
-    # bellow should have the opposite
+    # below should have the opposite
     npt.assert_allclose(results["A"][0], -results["A"][1])
     npt.assert_allclose(np.sign(results["A"][0]), -np.sign(density))
     npt.assert_allclose(np.sign(results["A"][1]), np.sign(density))
@@ -294,12 +294,12 @@ def test_g_z_symmetry_inside():
         npt.assert_allclose(0, results[group])
     # Values on C and D, F and G must be opposite
     # Moreover, the set of points that are above the center of the prism must
-    # have the same sign as the density, while the ones bellow should have the
+    # have the same sign as the density, while the ones below should have the
     # opposite
-    for above, bellow in (("C", "D"), ("F", "G")):
-        npt.assert_allclose(results[above], -results[bellow])
+    for above, below in (("C", "D"), ("F", "G")):
+        npt.assert_allclose(results[above], -results[below])
         npt.assert_allclose(np.sign(results[above]), np.sign(density))
-        npt.assert_allclose(np.sign(results[bellow]), -np.sign(density))
+        npt.assert_allclose(np.sign(results[below]), -np.sign(density))
 
 
 @pytest.mark.use_numba

--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -588,7 +588,7 @@ def test_spherical_shell_two_dim_adaptive_discret():  # pylint: disable=too-many
                 tesseroids.append([w, e, s, n, bottom, top])
         # Get analytical solutions
         analytical = spherical_shell_analytical(top, bottom, density, radius)
-        # Assert analytical and numerical solution are bellow the accuracy
+        # Assert analytical and numerical solution are below the accuracy
         # threshold
         for field in analytical:
             npt.assert_allclose(
@@ -632,7 +632,7 @@ def test_spherical_shell_three_dim_adaptive_discret():  # pylint: disable=too-ma
                 tesseroids.append([w, e, s, n, bottom, top])
         # Get analytical solutions
         analytical = spherical_shell_analytical(top, bottom, density, radius)
-        # Assert analytical and numerical solution are bellow the accuracy
+        # Assert analytical and numerical solution are below the accuracy
         # threshold
         for field in analytical:
             npt.assert_allclose(


### PR DESCRIPTION
Replace a typo on "below" across docstrings and comments.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
