### PR TITLE
Run CIs only on the two ends of supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.9]
         # If "optional", will install non-required dependencies in the build
         # environment. Otherwise, only required dependencies are installed.
         dependencies: [""]


### PR DESCRIPTION
Instead of running the test suite on CIs over each supported Python version,
limit it only to the two ends. Currently, they are Python 3.6 and Python 3.9.

Suggested by @leouieda on #240 



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
