### PR TITLE
Fix typo on changelog

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,7 @@ Version 0.3.2
 
 Bug fixes:
 
-- Fix import of Harmonica version on sample datasets: solves a problem whenbuilding docs for releases. Define the ``__version__`` variable inside a new `version.py`` file. (`#264 <https://github.com/fatiando/harmonica/pull/264>`__)
+- Fix import of Harmonica version on sample datasets: solves a problem whenbuilding docs for releases. Define the ``__version__`` variable inside a new ``version.py`` file. (`#264 <https://github.com/fatiando/harmonica/pull/264>`__)
 
 This release contains contributions from:
 


### PR DESCRIPTION
Fix a typo on RST markup in changelog.





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
