### PR TITLE
Add EquivalentSources to API index

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -23,8 +23,8 @@ Equivalent Layers
 .. autosummary::
     :toctree: generated/
 
-    EQLHarmonic
-    EQLHarmonicSpherical
+    EquivalentSources
+    EquivalentSourcesSph
 
 Forward modelling
 -----------------


### PR DESCRIPTION
Replace `EQLHarmonic` and `EQLHarmonicSpherical` for `EquivalentSources` and
`EquivalentSourcesSph` in `doc/api/index.rst`.

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
