### PR TITLE
Fix and rename pytest mark to run only with Numba enabled

### DIFF
--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -22,7 +22,7 @@ from ..equivalent_sources.utils import (
     jacobian_numba_serial,
     pop_extra_coords,
 )
-from .utils import test_only_with_numba
+from .utils import run_only_with_numba
 
 
 def test_pop_extra_coords():
@@ -43,7 +43,7 @@ def test_pop_extra_coords():
     assert kwargs == {"bla": 1, "blabla": 2}
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_equivalent_sources_cartesian():
     """
     Check that predictions are reasonable when interpolating from one grid to
@@ -301,7 +301,7 @@ def test_equivalent_sources_jacobian_cartesian():
     npt.assert_allclose(jacobian[nearest_neighbours][0], jacobian[nearest_neighbours])
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_equivalent_sources_cartesian_parallel():
     """
     Check predictions when parallel is enabled and disabled

--- a/harmonica/tests/test_eq_sources_spherical.py
+++ b/harmonica/tests/test_eq_sources_spherical.py
@@ -15,10 +15,10 @@ import xarray.testing as xrt
 import verde as vd
 
 from .. import EquivalentSourcesSph, EQLHarmonicSpherical, point_mass_gravity
-from .utils import test_only_with_numba
+from .utils import run_only_with_numba
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_equivalent_sources_spherical():
     """
     Check that predictions are reasonable when interpolating from one grid to
@@ -164,7 +164,7 @@ def test_equivalent_sources_spherical_no_projection():
         eqs.grid(upward=10, projection=lambda a, b: (a * 2, b * 2))
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_equivalent_sources_spherical_parallel():
     """
     Check predictions when parallel is enabled and disabled

--- a/harmonica/tests/test_point_mass.py
+++ b/harmonica/tests/test_point_mass.py
@@ -16,7 +16,7 @@ from ..constants import GRAVITATIONAL_CONST
 from ..forward.point_mass import point_mass_gravity
 from ..forward.utils import distance_cartesian
 
-from .utils import test_only_with_numba
+from .utils import run_only_with_numba
 
 
 def test_invalid_coordinate_system():
@@ -596,7 +596,7 @@ def test_g_easting_sign():
     assert np.sign(mass) == -np.sign(results[2])
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_point_mass_cartesian_parallel():
     """
     Check if parallel and serial runs return the same result
@@ -735,7 +735,7 @@ def test_point_mass_potential_on_same_meridian():
                 )
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_point_mass_spherical_parallel():
     """
     Check if parallel and serial runs return the same result

--- a/harmonica/tests/test_prism.py
+++ b/harmonica/tests/test_prism.py
@@ -15,7 +15,7 @@ import verde as vd
 from ..gravity_corrections import bouguer_correction
 from ..forward.prism import prism_gravity, _check_prisms, safe_atan2, safe_log
 
-from .utils import test_only_with_numba
+from .utils import run_only_with_numba
 
 
 def test_invalid_field():
@@ -363,7 +363,7 @@ def test_prism_against_infinite_slab():
     npt.assert_allclose(analytical, results[-1])
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_prisms_parallel_vs_serial():
     """
     Check if the parallelized run returns the same results as the serial one

--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -13,7 +13,7 @@ import pytest
 from verde import grid_coordinates
 import boule
 
-from .utils import test_only_with_numba
+from .utils import run_only_with_numba
 from ..constants import GRAVITATIONAL_CONST
 from ..forward.tesseroid import (
     tesseroid_gravity,
@@ -467,7 +467,7 @@ def test_split_tesseroid_only_horizontal():
 # ----------------------------
 # Test adaptive discretization
 # ----------------------------
-@test_only_with_numba
+@run_only_with_numba
 @pytest.mark.parametrize("radial_discretization", [True, False])
 def test_adaptive_discretization_on_radii(radial_discretization):
     "Test if closer computation points increase the tesseroid discretization"
@@ -498,7 +498,7 @@ def test_adaptive_discretization_on_radii(radial_discretization):
         assert number_of_splits[i - 1] >= number_of_splits[i]
 
 
-@test_only_with_numba
+@run_only_with_numba
 @pytest.mark.parametrize("radial_discretization", [True, False])
 def test_adaptive_discretization_vs_distance_size_ratio(radial_discretization):
     "Test if higher distance-size-ratio increase the tesseroid discretization"
@@ -522,7 +522,7 @@ def test_adaptive_discretization_vs_distance_size_ratio(radial_discretization):
         assert number_of_splits[i - 1] <= number_of_splits[i]
 
 
-@test_only_with_numba
+@run_only_with_numba
 def test_two_dimensional_adaptive_discretization():
     """
     Test if 2D adaptive discretization produces no splits on radial direction
@@ -567,7 +567,7 @@ def spherical_shell_analytical(top, bottom, density, radius):
     return analytical
 
 
-@test_only_with_numba
+@run_only_with_numba
 @pytest.mark.parametrize("field", ["potential", "g_z"])
 def test_spherical_shell_two_dim_adaptive_discret(
     field,
@@ -613,7 +613,7 @@ def test_spherical_shell_two_dim_adaptive_discret(
         )
 
 
-@test_only_with_numba
+@run_only_with_numba
 @pytest.mark.parametrize("field", ["potential", "g_z"])
 @pytest.mark.parametrize("thickness", [10, 100, 1e3, 1e4, 1e5])
 def test_spherical_shell_three_dim_adaptive_discret(

--- a/harmonica/tests/utils.py
+++ b/harmonica/tests/utils.py
@@ -43,7 +43,7 @@ NUMBA_IS_DISABLED = bool(os.environ.get("NUMBA_DISABLE_JIT", default="0") != "0"
 # ``@pytest.mark.use_numba`` instead. Therefore the test function will be run
 # twice: one with Numba jit enabled, and another one with Numba jit disable to
 # check coverage.
-test_only_with_numba = combine_decorators(
+run_only_with_numba = combine_decorators(
     pytest.mark.skipif(NUMBA_IS_DISABLED, reason="Numba jit is disabled"),
     pytest.mark.use_numba,
 )


### PR DESCRIPTION
Fix bug on the `require_numba` mark: tests decorated only with it weren't being
tested. Now it combines the `pytest.mark.use_numba` decorator. Rename the
decorator to `run_only_with_numba` for better readability.


**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
