### PR TITLE
Fix typo on EquivalentSources docstring

### DIFF
--- a/harmonica/equivalent_sources/cartesian.py
+++ b/harmonica/equivalent_sources/cartesian.py
@@ -71,7 +71,7 @@ class EquivalentSources(vdb.BaseGridder):
     put the sources _above_ them.
 
     Custom source locations can be chosen by specifying the ``points``
-    argument, in which case the ``depth_type``, ``bloc_size`` and ``depth``
+    argument, in which case the ``depth_type``, ``block_size`` and ``depth``
     arguments will be ignored.
 
     The corresponding coefficient for each point source is estimated through


### PR DESCRIPTION
Fix typo en `EquivalentSources` docstring: replace `bloc_size` for `block_size`.



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
