### PR TITLE
Add dtype argument to EquivalentSources

### DIFF
--- a/harmonica/equivalent_sources/cartesian.py
+++ b/harmonica/equivalent_sources/cartesian.py
@@ -25,7 +25,9 @@ from .utils import (
 from ..forward.utils import distance_cartesian
 
 
-class EquivalentSources(vdb.BaseGridder):
+class EquivalentSources(
+    vdb.BaseGridder
+):  # pylint: disable=too-many-instance-attributes
     r"""
     Equivalent sources for generic harmonic functions (gravity, magnetics).
 

--- a/harmonica/equivalent_sources/cartesian.py
+++ b/harmonica/equivalent_sources/cartesian.py
@@ -341,7 +341,7 @@ class EquivalentSources(vdb.BaseGridder):
         )
         return data.reshape(shape)
 
-    def jacobian(self, coordinates, points):  # pylint: disable=no-self-use
+    def jacobian(self, coordinates, points):
         """
         Make the Jacobian matrix for the equivalent sources.
 
@@ -352,13 +352,13 @@ class EquivalentSources(vdb.BaseGridder):
         ----------
         coordinates : tuple of arrays
             Arrays with the coordinates of each data point. Should be in the
-            following order: (``easting``, ``northing``, ``upward``, ...).
-            Only ``easting``, ``northing`` and ``upward`` will be used, all
-            subsequent coordinates will be ignored.
+            following order: (``easting``, ``northing``, ``upward``).
+            Each array must be 1D.
         points : tuple of arrays
             Tuple of arrays containing the coordinates of the equivalent point
             sources in the following order:
             (``easting``, ``northing``, ``upward``).
+            Each array must be 1D.
 
         Returns
         -------

--- a/harmonica/equivalent_sources/utils.py
+++ b/harmonica/equivalent_sources/utils.py
@@ -11,6 +11,32 @@ from warnings import warn
 from numba import jit, prange
 
 
+def cast_fit_input(coordinates, data, weights, dtype):
+    """
+    Cast the inputs of the fit method to the given dtype
+
+    Parameters
+    ----------
+    coordinates : tuple of arrays
+        Arrays with the coordinates of each data point. Should be in the
+        following order: (easting, northing, vertical, ...).
+    data : array
+        The data values of each data point.
+    weights : None or array
+        If not None, then the weights assigned to each data point.
+
+    Returns
+    -------
+    casted_inputs
+        The casted inputs in the same order.
+    """
+    coordinates = tuple(c.astype(dtype) for c in coordinates)
+    data = data.astype(dtype)
+    if weights is not None:
+        weights = weights.astype(dtype)
+    return coordinates, data, weights
+
+
 def pop_extra_coords(kwargs):
     """
     Remove extra_coords from kwargs

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -86,7 +86,7 @@ def fixture_coordinates_small(region):
 
 
 @pytest.fixture(name="data_small")
-def fixture_data_small(region, points, masses, coordinates_small):
+def fixture_data_small(points, masses, coordinates_small):
     """
     Return some sample data for the small set of coordinates
     """
@@ -274,9 +274,7 @@ def test_equivalent_sources_invalid_depth_type():
         EquivalentSources(depth=300, depth_type="blabla")
 
 
-def test_equivalent_sources_points_depth(
-    region, points, masses, coordinates_small, data_small
-):
+def test_equivalent_sources_points_depth(points, coordinates_small, data_small):
     """
     Check if the points coordinates are properly defined by the fit method
     """
@@ -378,9 +376,7 @@ def test_equivalent_sources_cartesian_parallel(region, coordinates, data):
 
 
 @pytest.mark.parametrize("depth_type", ("constant", "relative"))
-def test_backward_eqlharmonic(
-    region, points, masses, coordinates_small, data_small, depth_type
-):
+def test_backward_eqlharmonic(region, coordinates_small, data_small, depth_type):
     """
     Check backward compatibility with to-be-deprecated EQLHarmonic class
 

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -412,9 +412,6 @@ def test_backward_eqlharmonic(depth_type):
     )
 
 
-#  @pytest.mark.use_numba
-
-
 @run_only_with_numba
 @pytest.mark.parametrize(
     "block_size", (None, 500), ids=["block_size_none", "block_size_500"]

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -442,8 +442,8 @@ def test_dtype(region, block_size, custom_points, weights_none, dtype):
     # Make some predictions
     prediction = eqs.predict(coordinates)
     # Check data type of created objects
-    for p in eqs.points_:
-        assert p.dtype == np.dtype(dtype)
+    for coord in eqs.points_:
+        assert coord.dtype == np.dtype(dtype)
     assert prediction.dtype == np.dtype(dtype)
 
 
@@ -453,8 +453,9 @@ def test_jacobian_dtype(region, dtype):
     """
     Test dtype of Jacobian when changing dtype argument on EquivalentSources
     """
-    _, _, coordinates, data, weights = build_sample_sources_and_data(
-        region, coords_shape=(10, 10)
+    # Build a set of custom coordinates
+    coordinates = tuple(
+        c.ravel() for c in vd.grid_coordinates(region, shape=(10, 10), extra_coords=0)
     )
     # Create custom set of point sources
     points = tuple(

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -408,16 +408,21 @@ def test_backward_eqlharmonic(
 
 
 @run_only_with_numba
-@pytest.mark.parametrize(
-    "block_size", (None, 500), ids=["block_size_none", "block_size_500"]
-)
-@pytest.mark.parametrize(
-    "custom_points", (False, True), ids=["no_custom_points", "custom_points"]
-)
+@pytest.mark.parametrize("block_size", (None, 500), ids=["no_blocks", "blocks"])
+@pytest.mark.parametrize("custom_points", (False, True), ids=["no_points", "points"])
 @pytest.mark.parametrize("weights_none", (False, True), ids=["no_weights", "weights"])
+@pytest.mark.parametrize("damping", (None, 0.1), ids=["damping_none", "damping"])
 @pytest.mark.parametrize("dtype", ("float64", "float32"))
 def test_dtype(
-    region, coordinates, data, weights, block_size, custom_points, weights_none, dtype
+    region,
+    coordinates,
+    data,
+    weights,
+    block_size,
+    custom_points,
+    weights_none,
+    damping,
+    dtype,
 ):
     """
     Test dtype argument on EquivalentSources
@@ -430,7 +435,9 @@ def test_dtype(
     if weights_none:
         weights = None
     # Initialize and fit the equivalent sources
-    eqs = EquivalentSources(points=points, block_size=block_size, dtype=dtype)
+    eqs = EquivalentSources(
+        damping=damping, points=points, block_size=block_size, dtype=dtype
+    )
     eqs.fit(coordinates, data, weights)
     # Make some predictions
     prediction = eqs.predict(coordinates)
@@ -438,6 +445,8 @@ def test_dtype(
     for coord in eqs.points_:
         assert coord.dtype == np.dtype(dtype)
     assert prediction.dtype == np.dtype(dtype)
+    # Check the data type of the source coefficients
+    #  assert eqs.coefs_.dtype == np.dtype(dtype)
 
 
 @pytest.mark.use_numba

--- a/harmonica/tests/test_eq_sources_utils.py
+++ b/harmonica/tests/test_eq_sources_utils.py
@@ -49,8 +49,8 @@ def test_cast_fit_input(weights_none, dtype):
         weights = np.ones_like(data)
     coordinates, data, weights = cast_fit_input(coordinates, data, weights, dtype)
     # Check dtype of the outputs
-    for c in coordinates:
-        assert c.dtype == np.dtype(dtype)
+    for coord in coordinates:
+        assert coord.dtype == np.dtype(dtype)
     assert data.dtype == np.dtype(dtype)
     if weights_none:
         assert weights is None

--- a/harmonica/tests/test_eq_sources_utils.py
+++ b/harmonica/tests/test_eq_sources_utils.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2018 The Harmonica Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+# pylint: disable=protected-access
+"""
+Test equivalent sources utility functions
+"""
+import warnings
+import pytest
+import numpy as np
+from verde import scatter_points
+
+from ..equivalent_sources.utils import pop_extra_coords, cast_fit_input
+
+
+def test_pop_extra_coords():
+    """
+    Test pop_extra_coords private function
+    """
+    # Check if extra_coords is removed from kwargs
+    kwargs = {"bla": 1, "blabla": 2, "extra_coords": 1400.0}
+    with warnings.catch_warnings(record=True) as warn:
+        pop_extra_coords(kwargs)
+        assert len(warn) == 1
+        assert issubclass(warn[0].category, UserWarning)
+    assert "extra_coords" not in kwargs
+
+    # Check if kwargs is not touched if no extra_coords are present
+    kwargs = {"bla": 1, "blabla": 2}
+    pop_extra_coords(kwargs)
+    assert kwargs == {"bla": 1, "blabla": 2}
+
+
+@pytest.mark.parametrize("weights_none", (False, True))
+@pytest.mark.parametrize("dtype", ("float64", "float32", "int32", "int64"))
+def test_cast_fit_input(weights_none, dtype):
+    """
+    Test cast_fit_input function
+    """
+    region = (-7e3, 4e3, 10e3, 25e3)
+    coordinates = scatter_points(region=region, size=100, random_state=42)
+    data = np.arange(coordinates[0].size, dtype="float64")
+    if weights_none:
+        weights = None
+    else:
+        weights = np.ones_like(data)
+    coordinates, data, weights = cast_fit_input(coordinates, data, weights, dtype)
+    # Check dtype of the outputs
+    for c in coordinates:
+        assert c.dtype == np.dtype(dtype)
+    assert data.dtype == np.dtype(dtype)
+    if weights_none:
+        assert weights is None
+    else:
+        assert weights.dtype == np.dtype(dtype)


### PR DESCRIPTION
The `dtype` argument is used to cast the inputs of the `fit` method, to build
the location of the point sources, to allocate the Jacobian matrix and
therefore to produce predictions. Add a new utility function for casting the
inputs of the fit method to the desired `dtype`. Add new test file for the
equivalent sources utility functions. Add tests for the new feature. Simplify
test suite for equivalent sources through fixtures.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
