### PR TITLE
Add warning about future deprecation of datasets module

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -71,6 +71,12 @@ Synthetic models and surveys
 Datasets
 --------
 
+.. warning::
+
+   The datasets module will soon be deprecated.
+   Use `Ensaio <https://www.fatiando.org/ensaio>`_ to download sample datasets
+   instead.
+
 .. autosummary::
    :toctree: generated/
 

--- a/harmonica/datasets/sample_data.py
+++ b/harmonica/datasets/sample_data.py
@@ -8,6 +8,7 @@
 Functions to load sample datasets used in the Harmonica docs.
 """
 import pandas as pd
+import warnings
 import pkg_resources
 import pooch
 import xarray as xr
@@ -25,6 +26,18 @@ with pkg_resources.resource_stream(
     "harmonica.datasets", "registry.txt"
 ) as registry_file:
     REGISTRY.load_registry(registry_file)
+
+
+def _raise_future_warning():
+    """
+    Raise FutureWarning about deprecation of datasets module
+    """
+    warnings.warn(
+        "The datasets module will be deprecated in Harmonica v0.6.0. "
+        + "Please, use Ensaio (www.fatiando.org/ensaio) to download sample datasets "
+        + "instead.",
+        FutureWarning,
+    )
 
 
 def locate():
@@ -69,6 +82,7 @@ def fetch_geoid_earth():
         longitude.
 
     """
+    _raise_future_warning()
     fname = REGISTRY.fetch("geoid-earth-0.5deg.nc.xz", processor=pooch.Decompress())
     data = xr.open_dataset(fname, engine="scipy")
     # Capture attributes dict because it's removed after converting the data to
@@ -104,6 +118,7 @@ def fetch_gravity_earth():
         longitude.
 
     """
+    _raise_future_warning()
     fname = REGISTRY.fetch("gravity-earth-0.5deg.nc.xz", processor=pooch.Decompress())
     data = xr.open_dataset(fname, engine="scipy")
     # Capture attributes dict because it's removed after converting the data to
@@ -140,6 +155,7 @@ def fetch_topography_earth():
         geodetic latitude and longitude.
 
     """
+    _raise_future_warning()
     fname = REGISTRY.fetch("etopo1-0.5deg.nc.xz", processor=pooch.Decompress())
     data = xr.open_dataset(fname, engine="scipy")
     # Capture attributes dict because it's removed after converting the data to
@@ -182,6 +198,7 @@ def fetch_britain_magnetic():
     data : :class:`pandas.DataFrame`
         The magnetic anomaly data.
     """
+    _raise_future_warning()
     return pd.read_csv(REGISTRY.fetch("britain-magnetic.csv.xz"), compression="xz")
 
 
@@ -212,6 +229,7 @@ def fetch_south_africa_gravity():
         The gravity data.
 
     """
+    _raise_future_warning()
     fname = REGISTRY.fetch("south-africa-gravity.ast.xz")
     columns = ["latitude", "longitude", "elevation", "gravity"]
     return pd.read_csv(fname, sep=r"\s+", names=columns, compression="xz")
@@ -238,6 +256,7 @@ def fetch_south_africa_topography():
         geodetic latitude and longitude.
 
     """
+    _raise_future_warning()
     fname = REGISTRY.fetch(
         "south-africa-topography.nc.xz", processor=pooch.Decompress()
     )

--- a/harmonica/datasets/sample_data.py
+++ b/harmonica/datasets/sample_data.py
@@ -7,8 +7,9 @@
 """
 Functions to load sample datasets used in the Harmonica docs.
 """
-import pandas as pd
 import warnings
+
+import pandas as pd
 import pkg_resources
 import pooch
 import xarray as xr

--- a/harmonica/tests/test_sample_data.py
+++ b/harmonica/tests/test_sample_data.py
@@ -8,10 +8,10 @@
 Test the sample data loading functions.
 """
 import os
-import pytest
 import warnings
 
 import numpy.testing as npt
+import pytest
 
 from ..datasets.sample_data import (
     fetch_britain_magnetic,

--- a/harmonica/tests/test_sample_data.py
+++ b/harmonica/tests/test_sample_data.py
@@ -8,6 +8,8 @@
 Test the sample data loading functions.
 """
 import os
+import pytest
+import warnings
 
 import numpy.testing as npt
 
@@ -22,6 +24,26 @@ from ..datasets.sample_data import (
 )
 
 
+@pytest.mark.parametrize(
+    "fetch_function",
+    (
+        fetch_britain_magnetic,
+        fetch_geoid_earth,
+        fetch_gravity_earth,
+        fetch_south_africa_gravity,
+        fetch_south_africa_topography,
+        fetch_topography_earth,
+    ),
+)
+def test_future_warning(fetch_function):
+    "Check if a FutureWarning is raised after calling any fetch function"
+    with warnings.catch_warnings(record=True) as warn:
+        fetch_function()
+        assert len(warn) == 1
+        assert issubclass(warn[0].category, FutureWarning)
+
+
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_datasets_locate():
     "Make sure the data cache location has the right package name"
     # Fetch a dataset first to make sure that the cache folder exists. Since
@@ -34,6 +56,7 @@ def test_datasets_locate():
     assert "harmonica" in path
 
 
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_geoid_earth():
     "Sanity checks for the loaded grid"
     grid = fetch_geoid_earth()
@@ -47,6 +70,7 @@ def test_geoid_earth():
     assert grid.attrs.get("modelname") == "EIGEN-6C4"
 
 
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_gravity_earth():
     "Sanity checks for the loaded grid"
     grid = fetch_gravity_earth()
@@ -62,6 +86,7 @@ def test_gravity_earth():
     assert grid.attrs.get("modelname") == "EIGEN-6C4"
 
 
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_topography_earth():
     "Sanity checks for the loaded grid"
     grid = fetch_topography_earth()
@@ -74,6 +99,7 @@ def test_topography_earth():
     assert grid.attrs.get("modelname") == "etopo1-2250"
 
 
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_britain_magnetic():
     "Sanity checks for the loaded dataset"
     data = fetch_britain_magnetic()
@@ -104,6 +130,7 @@ def test_britain_magnetic():
     }
 
 
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_south_africa_gravity():
     "Sanity checks for the loaded dataset"
     data = fetch_south_africa_gravity()
@@ -118,6 +145,7 @@ def test_south_africa_gravity():
     npt.assert_allclose(data.gravity.max(), 979766.65)
 
 
+@pytest.mark.filterwarnings("ignore:The dataset module will be deprecated")
 def test_south_africa_topography():
     "Sanity checks for the loaded dataset"
     data = fetch_south_africa_topography()


### PR DESCRIPTION
**Description**

In a future release, Harmonica will ditch the self-hosted sample datasets and
replace them by using Ensaio to fetch them when needed. Add FutureWarnings to
each fetch function in the datasets module and point users to Ensaio. Add test
function for these new FutureWarnings. Add warning in Datasets section in API
Reference.
