### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           - macos
           - windows
         python:
-          - "3.6"
+          - "3.7"
           - "3.9"
         dependencies:
           - latest

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.6 or greater**.
+You'll need **Python 3.7 or greater**.
 
 We recommend using the
 `Anaconda Python distribution <https://www.anaconda.com/download>`__

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ project_urls =
 zip_safe = True
 include_package_data = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     numpy
     pandas


### PR DESCRIPTION
**Description**
Remove the compatibility metadata, remove from the CI matrix, bump the
`python_requires` to 3.7+.


**Relevant issues/PRs**
Inspired on https://github.com/fatiando/verde/pull/364 and triggered by CI errors in #238 