### PR TITLE
Remove deprecated point_mass_gravity function

### DIFF
--- a/harmonica/__init__.py
+++ b/harmonica/__init__.py
@@ -11,7 +11,7 @@ from ._version import __version__
 from .equivalent_sources.cartesian import EQLHarmonic, EquivalentSources
 from .equivalent_sources.gradient_boosted import EquivalentSourcesGB
 from .equivalent_sources.spherical import EQLHarmonicSpherical, EquivalentSourcesSph
-from .forward.point import point_gravity, point_mass_gravity
+from .forward.point import point_gravity
 from .forward.prism import prism_gravity
 from .forward.prism_layer import DatasetAccessorPrismLayer, prism_layer
 from .forward.tesseroid import tesseroid_gravity

--- a/harmonica/forward/point.py
+++ b/harmonica/forward/point.py
@@ -7,7 +7,6 @@
 """
 Forward modelling for point masses
 """
-import warnings
 
 import numpy as np
 from numba import jit, prange

--- a/harmonica/forward/point.py
+++ b/harmonica/forward/point.py
@@ -227,37 +227,6 @@ def point_gravity(
     return result.reshape(cast.shape)
 
 
-def point_mass_gravity(
-    coordinates,
-    points,
-    masses,
-    field,
-    coordinate_system="cartesian",
-    parallel=True,
-    dtype="float64",
-):
-    """
-    DEPRECATED. Use :func:`harmonica.point_gravity` instead.
-
-    This function exists to support backward compatibility until next release.
-    """
-    warnings.warn(
-        "The 'point_mass_gravity' function has been renamed to 'point_gravity' "
-        + "and will be deprecated on the next release, "
-        + "please use 'point_gravity' instead.",
-        FutureWarning,
-    )
-    return point_gravity(
-        coordinates=coordinates,
-        points=points,
-        masses=masses,
-        field=field,
-        coordinate_system=coordinate_system,
-        parallel=parallel,
-        dtype=dtype,
-    )
-
-
 def dispatcher(coordinate_system, parallel):
     """
     Return the appropriate forward model function

--- a/harmonica/tests/test_point_gravity.py
+++ b/harmonica/tests/test_point_gravity.py
@@ -17,7 +17,7 @@ import pytest
 import verde as vd
 
 from ..constants import GRAVITATIONAL_CONST
-from ..forward.point import point_gravity, point_mass_gravity
+from ..forward.point import point_gravity
 from ..forward.utils import distance_cartesian
 from .utils import run_only_with_numba
 
@@ -130,22 +130,6 @@ def test_potential_cartesian_known_values(point_mass, sample_coordinates_potenti
     precomputed_potential = sample_coordinates_potential[-1]
     # Compute potential gravity field on each computation point
     results = point_gravity(coordinates, point, mass, "potential", "cartesian")
-    npt.assert_allclose(results, precomputed_potential)
-
-
-@pytest.mark.use_numba
-def test_point_mass_gravity_deprecated(point_mass, sample_coordinates_potential):
-    """
-    Test the soon-to-be-deprecated point_mass_gravity function
-    """
-    point, mass = point_mass[:]
-    coordinates = sample_coordinates_potential[:3]
-    precomputed_potential = sample_coordinates_potential[-1]
-    # Check if a FutureWarning is raised
-    with warnings.catch_warnings(record=True) as warn:
-        results = point_mass_gravity(coordinates, point, mass, "potential", "cartesian")
-        assert len(warn) == 1
-        assert issubclass(warn[-1].category, FutureWarning)
     npt.assert_allclose(results, precomputed_potential)
 
 

--- a/harmonica/tests/test_point_gravity.py
+++ b/harmonica/tests/test_point_gravity.py
@@ -8,7 +8,6 @@
 Test forward modelling for point masses.
 """
 import os
-import warnings
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
Remove point_mass_gravity function from harmonica because it was deprecated on
PR #280. Remove related test functions.

Fix #308