### PR TITLE
Ditch soon-to-be deprecated args of equivalent sources grid method

### DIFF
--- a/examples/equivalent_sources/block_averaged_sources.py
+++ b/examples/equivalent_sources/block_averaged_sources.py
@@ -82,7 +82,8 @@ print("R² score:", eqs.score(coordinates, data.total_field_anomaly_nt))
 # requires the height of the grid points (upward coordinate). By passing in
 # 1500 m, we're effectively upward-continuing the data (mean flight height is
 # 500 m).
-grid = eqs.grid(upward=1500, spacing=500, data_names=["magnetic_anomaly"])
+grid_coords = vd.grid_coordinates(region=region, spacing=500, extra_coords=1500)
+grid = eqs.grid(coordinates=grid_coords, data_names=["magnetic_anomaly"])
 
 # The grid is a xarray.Dataset with values, coordinates, and metadata
 print("\nGenerated grid:\n", grid)

--- a/examples/equivalent_sources/cartesian.py
+++ b/examples/equivalent_sources/cartesian.py
@@ -71,7 +71,8 @@ print("R² score:", eqs.score(coordinates, data.total_field_anomaly_nt))
 # requires the height of the grid points (upward coordinate). By passing in
 # 1500 m, we're effectively upward-continuing the data (mean flight height is
 # 500 m).
-grid = eqs.grid(upward=1500, spacing=500, data_names=["magnetic_anomaly"])
+grid_coords = vd.grid_coordinates(region=region, spacing=500, extra_coords=1500)
+grid = eqs.grid(coordinates=grid_coords, data_names=["magnetic_anomaly"])
 
 # The grid is a xarray.Dataset with values, coordinates, and metadata
 print("\nGenerated grid:\n", grid)

--- a/examples/equivalent_sources/gradient_boosted.py
+++ b/examples/equivalent_sources/gradient_boosted.py
@@ -91,11 +91,8 @@ print("R² score:", eqs_gb.score(coordinates, data.gravity_disturbance))
 # Interpolate data on a regular grid with 2 km spacing. The interpolation
 # requires the height of the grid points (upward coordinate). By passing in
 # 1000 m, we're effectively upward-continuing the data.
-grid = eqs_gb.grid(
-    upward=1000,
-    spacing=2e3,
-    data_names="gravity_disturbance",
-)
+grid_coords = vd.grid_coordinates(region=region, spacing=2e3, extra_coords=1000)
+grid = eqs_gb.grid(coordinates=grid_coords, data_names="gravity_disturbance")
 print(grid)
 
 # Plot the original gravity disturbance and the gridded and upward-continued

--- a/examples/equivalent_sources/spherical.py
+++ b/examples/equivalent_sources/spherical.py
@@ -62,11 +62,10 @@ print("R² score:", eqs.score(coordinates, gravity_disturbance))
 # passing in the maximum radius of the data, we're effectively
 # upward-continuing the data. The grid will be defined in spherical
 # coordinates.
-grid = eqs.grid(
-    upward=coordinates[-1].max(),
-    spacing=0.2,
-    data_names=["gravity_disturbance"],
-)
+region = vd.get_region(coordinates)  # get the region boundaries
+upward = coordinates[-1].max()
+grid_coords = vd.grid_coordinates(region=region, spacing=0.2, extra_coords=upward)
+grid = eqs.grid(coordinates=grid_coords, data_names=["gravity_disturbance"])
 
 # The grid is a xarray.Dataset with values, coordinates, and metadata
 print("\nGenerated grid:\n", grid)
@@ -78,9 +77,6 @@ grid = vd.distance_mask(data_coordinates=coordinates, maxdist=0.5, grid=grid)
 # can use the same color scale for both plots and have 0 centered at the white
 # color.
 maxabs = vd.maxabs(gravity_disturbance, grid.gravity_disturbance.values)
-
-# Get the region boundaries
-region = vd.get_region(coordinates)
 
 # Plot observed and gridded gravity disturbance
 fig, (ax1, ax2) = plt.subplots(

--- a/harmonica/equivalent_sources/cartesian.py
+++ b/harmonica/equivalent_sources/cartesian.py
@@ -377,10 +377,7 @@ class EquivalentSources(vdb.BaseGridder):
 
     def grid(
         self,
-        upward,
-        region=None,
-        shape=None,
-        spacing=None,
+        coordinates,
         dims=None,
         data_names=None,
         projection=None,
@@ -389,31 +386,27 @@ class EquivalentSources(vdb.BaseGridder):
         """
         Interpolate the data onto a regular grid.
 
-        The grid can be specified by either the number of points in each
-        dimension (the *shape*) or by the grid node spacing. See
-        :func:`verde.grid_coordinates` for details. All grid points will be
-        located at the same `upward` coordinate. Other arguments for
-        :func:`verde.grid_coordinates` can be passed as extra keyword arguments
-        (``kwargs``) to this method.
+        The coordinates of the regular grid must be passed through the
+        ``coordinates`` argument as a tuple containing three arrays in the
+        following order: ``(easting, nothing, upward)``. They can be easily
+        created through the :func:`verde.grid_coordinates` function. If the
+        grid points must be all at the same height, it can be specified in the
+        ``extra_coords`` argument of :func:`verde.grid_coordinates`.
 
-        If the interpolator collected the input data region, then it will be
-        used if ``region=None``. Otherwise, you must specify the grid region.
         Use the *dims* and *data_names* arguments to set custom names for the
         dimensions and the data field(s) in the output :class:`xarray.Dataset`.
         Default names will be provided if none are given.
 
         Parameters
         ----------
-        upward : float
-            Upward coordinate of the grid points.
-        region : list = [W, E, S, N]
-            The west, east, south, and north boundaries of a given region.
-        shape : tuple = (n_north, n_east) or None
-            The number of points in the South-North and West-East directions,
-            respectively.
-        spacing : tuple = (s_north, s_east) or None
-            The grid spacing in the South-North and West-East directions,
-            respectively.
+        coordinates : tuple of arrays
+            Tuple of arrays containing the coordinates of the grid in the
+            following order: (easting, northing, upward).
+            The easting and northing arrays could be 1d or 2d arrays, if
+            they are 2d they must be part of a meshgrid.
+            The upward array should be a 2d array with the same shape of
+            easting and northing (if they are 2d arrays) or with a shape of
+            ``(northing.size, easting.size)`` (if they are 1d arrays).
         dims : list or None
             The names of the northing and easting data dimensions,
             respectively, in the output grid. Default is determined from the
@@ -439,22 +432,45 @@ class EquivalentSources(vdb.BaseGridder):
             The interpolated grid. Metadata about the interpolator is written
             to the ``attrs`` attribute.
 
-        """
-        # We override the grid method from BaseGridder so it takes the upward
-        # coordinate as a positional argument.
+        See also
+        --------
+        :func:`verde.grid_coordinates`
 
-        # Ignore extra_coords if passed
-        pop_extra_coords(kwargs)
+        """
+        # We override the grid method from BaseGridder to change the docstring
+        # and to make it work only with the `coordinates` argument (no region,
+        # shape or spacing)
+
+        # Raise ValueError if any deprecated argument has been passed
+        deprecated_args = (
+            "upward" in kwargs,
+            "shape" in kwargs,
+            "region" in kwargs,
+            "spacing" in kwargs,
+        )
+        if any(deprecated_args):
+            raise ValueError(
+                "The 'upward', 'region', 'shape' and 'spacing' arguments have been "
+                + "deprecated. "
+                + "Please pass the coordinates of the target grid through the "
+                + "'coordinates' argument."
+            )
+
+        # Raise warning if any kwargs has been passed
+        if kwargs:
+            args = "'" + "', '".join(list(kwargs.keys())) + "'"
+            warnings.warn(
+                f"The {args} arguments are being ignored. The 'grid' method "
+                + "will not take any keyword arguments in the next Harmonica release",
+                FutureWarning,
+            )
+
         # Grid data
         grid = super().grid(
-            region=region,
-            shape=shape,
-            spacing=spacing,
+            coordinates=coordinates,
             dims=dims,
             data_names=data_names,
             projection=projection,
-            extra_coords=upward,
-            **kwargs,
         )
         return grid
 

--- a/harmonica/equivalent_sources/spherical.py
+++ b/harmonica/equivalent_sources/spherical.py
@@ -268,12 +268,12 @@ class EquivalentSourcesSph(vdb.BaseGridder):
             longitude and latitude (if they are 2d arrays) or with a shape of
             ``(latitude.size, longitude.size)`` (if they are 1d arrays).
         dims : list or None
-            The names of the northing and easting data dimensions,
+            The names of the latitude and longitude data dimensions,
             respectively, in the output grid. Default is determined from the
             ``dims`` attribute of the class. Must be defined in the following
-            order: northing dimension, easting dimension.
-            **NOTE: This is an exception to the "easting" then
-            "northing" pattern but is required for compatibility with xarray.**
+            order: latitude dimension, longitude dimension.
+            **NOTE: This is an exception to the "longitude" then
+            "latitude" pattern but is required for compatibility with xarray.**
         data_names : list of None
             The name(s) of the data variables in the output grid. Defaults to
             ``['scalars']``.

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -393,7 +393,7 @@ def test_equivalent_sources_jacobian_cartesian():
 
 
 @run_only_with_numba
-def test_equivalent_sources_cartesian_parallel(region, coordinates, data):
+def test_equivalent_sources_cartesian_parallel(coordinates, data):
     """
     Check predictions when parallel is enabled and disabled
     """

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -120,12 +120,12 @@ def test_equivalent_sources_cartesian(region, points, masses, coordinates, data)
     # to synthetic values
     upward = 0
     shape = (60, 60)
-    grid = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
-    true = point_gravity(grid, points, masses, field="g_z")
-    npt.assert_allclose(true, eqs.predict(grid), rtol=1e-3)
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
+    true = point_gravity(grid_coords, points, masses, field="g_z")
+    npt.assert_allclose(true, eqs.predict(grid_coords), rtol=1e-3)
 
     # Test grid method
-    grid = eqs.grid(upward, shape=shape, region=region)
+    grid = eqs.grid(grid_coords)
     npt.assert_allclose(true, grid.scalars, rtol=1e-3)
 
     # Test profile method
@@ -155,12 +155,12 @@ def test_equivalent_sources_cartesian_float32(
     # to synthetic values
     upward = 0
     shape = (60, 60)
-    grid = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
-    true = point_gravity(grid, points, masses, field="g_z")
-    npt.assert_allclose(true, eqs.predict(grid), atol=1e-3 * vd.maxabs(true))
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
+    true = point_gravity(grid_coords, points, masses, field="g_z")
+    npt.assert_allclose(true, eqs.predict(grid_coords), atol=1e-3 * vd.maxabs(true))
 
     # Test grid method
-    grid = eqs.grid(upward, shape=shape, region=region)
+    grid = eqs.grid(grid_coords)
     npt.assert_allclose(true, grid.scalars, atol=1e-3 * vd.maxabs(true))
 
     # Test profile method
@@ -197,12 +197,12 @@ def test_equivalent_sources_small_data_cartesian(region, points, masses):
     # to synthetic values
     upward = 20
     shape = (8, 8)
-    grid = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
-    true = point_gravity(grid, points, masses, field="g_z")
-    npt.assert_allclose(true, eqs.predict(grid), rtol=0.08)
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
+    true = point_gravity(grid_coords, points, masses, field="g_z")
+    npt.assert_allclose(true, eqs.predict(grid_coords), rtol=0.08)
 
     # Test grid method
-    grid = eqs.grid(upward, shape=shape, region=region)
+    grid = eqs.grid(grid_coords)
     npt.assert_allclose(true, grid.scalars, rtol=0.08)
 
     # Test profile method
@@ -405,8 +405,8 @@ def test_equivalent_sources_cartesian_parallel(region, coordinates, data):
 
     upward = 0
     shape = (60, 60)
-    grid_serial = eqs_serial.grid(upward, shape=shape, region=region)
-    grid_parallel = eqs_parallel.grid(upward, shape=shape, region=region)
+    grid_serial = eqs_serial.grid(coordinates)
+    grid_parallel = eqs_parallel.grid(coordinates)
     npt.assert_allclose(grid_serial.scalars, grid_parallel.scalars, rtol=1e-7)
 
 
@@ -432,10 +432,8 @@ def test_backward_eqlharmonic(region, coordinates_small, data_small, depth_type)
     # Check if both gridders are equivalent
     npt.assert_allclose(eqs.points_, eql_harmonic.points_)
     shape = (8, 8)
-    xrt.assert_allclose(
-        eqs.grid(upward=2e3, shape=shape, region=region),
-        eql_harmonic.grid(upward=2e3, shape=shape, region=region),
-    )
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=2e3)
+    xrt.assert_allclose(eqs.grid(grid_coords), eql_harmonic.grid(grid_coords))
 
 
 @run_only_with_numba

--- a/harmonica/tests/test_eq_sources_spherical.py
+++ b/harmonica/tests/test_eq_sources_spherical.py
@@ -49,14 +49,14 @@ def test_equivalent_sources_spherical():
     # to synthetic values
     upward = radius
     shape = (60, 60)
-    grid = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
     true = point_gravity(
-        grid, points, masses, field="g_z", coordinate_system="spherical"
+        grid_coords, points, masses, field="g_z", coordinate_system="spherical"
     )
-    npt.assert_allclose(true, eqs.predict(grid), rtol=1e-3)
+    npt.assert_allclose(true, eqs.predict(grid_coords), rtol=1e-3)
 
     # Test grid method
-    grid = eqs.grid(upward, shape=shape, region=region)
+    grid = eqs.grid(grid_coords)
     npt.assert_allclose(true, grid.scalars, rtol=1e-3)
 
 
@@ -93,14 +93,14 @@ def test_equivalent_sources_small_data_spherical():
     # to synthetic values
     upward = radius + 2e3
     shape = (8, 8)
-    grid = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
     true = point_gravity(
-        grid, points, masses, field="g_z", coordinate_system="spherical"
+        grid_coords, points, masses, field="g_z", coordinate_system="spherical"
     )
-    npt.assert_allclose(true, eqs.predict(grid), rtol=0.05)
+    npt.assert_allclose(true, eqs.predict(grid_coords), rtol=0.05)
 
     # Test grid method
-    grid = eqs.grid(upward, shape=shape, region=region)
+    grid = eqs.grid(grid_coords)
     npt.assert_allclose(true, grid.scalars, rtol=0.05)
 
 
@@ -194,8 +194,9 @@ def test_equivalent_sources_spherical_parallel():
 
     upward = radius
     shape = (60, 60)
-    grid_serial = eqs_serial.grid(upward, shape=shape, region=region)
-    grid_parallel = eqs_parallel.grid(upward, shape=shape, region=region)
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=upward)
+    grid_serial = eqs_serial.grid(grid_coords)
+    grid_parallel = eqs_parallel.grid(grid_coords)
     npt.assert_allclose(grid_serial.scalars, grid_parallel.scalars, rtol=1e-7)
 
 
@@ -234,7 +235,8 @@ def test_backward_eqlharmonicspherical():
     # Check if both gridders are equivalent
     npt.assert_allclose(eqs.points_, eql_harmonic.points_)
     shape = (8, 8)
+    grid_coords = vd.grid_coordinates(region=region, shape=shape, extra_coords=6405e3)
     xrt.assert_allclose(
-        eqs.grid(upward=6405e3, shape=shape, region=region),
-        eql_harmonic.grid(upward=6405e3, shape=shape, region=region),
+        eqs.grid(grid_coords),
+        eql_harmonic.grid(grid_coords),
     )

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -336,3 +336,40 @@ def test_gradient_boosted_eqs_float32(coordinates, data):
     npt.assert_allclose(
         data, eqs.predict(coordinates), rtol=0, atol=0.05 * vd.maxabs(data)
     )
+
+
+@pytest.mark.parametrize(
+    "deprecated_args",
+    (
+        dict(upward=5e3, spacing=1),
+        dict(upward=5e3, shape=(6, 6)),
+        dict(upward=5e3, spacing=1, region=(-4e3, 0, 5e3, 7e3)),
+        dict(upward=5e3, shape=(6, 6), region=(-4e3, 0, 5e3, 7e3)),
+    ),
+)
+def test_error_deprecated_args(coordinates_small, data_small, region, deprecated_args):
+    """
+    Test if EquivalentSourcesGB.grid raises error on deprecated arguments
+    """
+    # Define sample equivalent sources and fit against synthetic data
+    eqs = EquivalentSourcesGB(window_size=500).fit(coordinates_small, data_small)
+    # Build a target grid
+    grid_coords = vd.grid_coordinates(region=region, shape=(4, 4), extra_coords=2e3)
+    # Try to grid passing deprecated arguments
+    msg = "The 'upward', 'region', 'shape' and 'spacing' arguments have been"
+    with pytest.raises(ValueError, match=msg):
+        eqs.grid(coordinates=grid_coords, **deprecated_args)
+
+
+def test_error_ignored_args(coordinates_small, data_small, region):
+    """
+    Test if EquivalentSourcesGB.grid raises warning on ignored arguments
+    """
+    # Define sample equivalent sources and fit against synthetic data
+    eqs = EquivalentSourcesGB(window_size=500).fit(coordinates_small, data_small)
+    # Build a target grid
+    grid_coords = vd.grid_coordinates(region=region, shape=(4, 4), extra_coords=2e3)
+    # Try to grid passing kwarg arguments that will be ignored
+    msg = "The 'bla' arguments are being ignored."
+    with pytest.warns(FutureWarning, match=msg):
+        eqs.grid(coordinates=grid_coords, bla="bla")


### PR DESCRIPTION
**Description**

The `grid()` method of Verde gridders now take a `coordinates` argument with
the coordinates of the target grid. The previous `region`, `shape` and
`spacing` arguments will be deprecated in Verde v2.0.0. This change makes it
easier for our equivalent sources classes: we don't need the extra `upward`
argument, users can create the coordinates of the target grid using
`verde.grid_coordinates` and pass them via `coordinates` argument. Ditch the
`upward`, `shape`, `spacing` and `region` arguments from the equivalent sources
gridders. Replace them for the new `coordinates` argument: users need to
provide the coordinates of the target grid instead of building it through the
grid method. Raise errors if any of those old arguments are being passed. Raise
warnings if any kwargs are passed: they are being ignored and not passed to the
`BaseGridder.grid()` method.


**Relevant issues/PRs**

https://github.com/fatiando/verde/pull/326


**TODO**:

- [x] Write test functions for the new errors and warnings
- [x] Apply changes in examples