### PR TITLE
Fix small format errors in the user guide

### DIFF
--- a/doc/user_guide/equivalent_sources/index.rst
+++ b/doc/user_guide/equivalent_sources/index.rst
@@ -99,7 +99,7 @@ disturbance.
    equivalent_sources.fit(coordinates, data.gravity_disturbance_mgal)
 
 Once the fitting process finishes, we can predict the values of the field on
-any set of points using the :meth:`EquivalentSources.predict` method.
+any set of points using the :meth:`harmonica.EquivalentSources.predict` method.
 For example, lets predict on the same observation points to check if the
 sources are able to reproduce the observed field.
 

--- a/doc/user_guide/topographic_correction.rst
+++ b/doc/user_guide/topographic_correction.rst
@@ -215,8 +215,8 @@ rectangular prisms. We can use the :func:`harmonica.prism_layer` function to
 build it.
 We also need to assign density values to each prism in the layer.
 For every prism above the ellipsoid we will set the density of the upper crust
-(2670 kg/m :math:`^3`), while for each prism below it we will assign the
-density contrast equal to the density of the water (1040 kg/m:math:`^3`) minus
+(2670 kg/m\ :sup:`3`), while for each prism below it we will assign the
+density contrast equal to the density of the water (1040 kg/m\ :sup:`3`) minus
 the density of the upper crust.
 
 .. jupyter-execute::


### PR DESCRIPTION
**Description**

Fix link to EquivalentSources.predict method and fix superscripts in the docs.