### PR TITLE
Specify "spherical latitude" when describing coordinates of point masses

### DIFF
--- a/doc/user_guide/forward_modelling/point.rst
+++ b/doc/user_guide/forward_modelling/point.rst
@@ -10,7 +10,7 @@ in Cartesian or in spherical coordinates.
 
 Each point mass can be defined as a tuple containing its coordinates in the
 following order: *easting*, *northing* and *upward* (in Cartesian coordinates)
-or *longitude*, *latitude* and *radius* (in spherical coordinates).
+or *longitude*, *spherical latitude* and *radius* (in spherical coordinates).
 
 Cartesian coordinates
 ---------------------


### PR DESCRIPTION
Add "spherical" when describing the spherical latitude coordinate of point
masses in the user guide. This way we differentiate it from the "latitude"
geodetic coordinate.

I just add 'spherical' following the description of the coordinate system where 'latitude' is used for geodetic (NOT spherical) coordinates.

Is this correct? Now I have some doubts. 