### PR TITLE
Avoid checking floats in tesseroid doctests

### DIFF
--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -126,8 +126,7 @@ def tesseroid_gravity(
     >>> # Define computation point located on the top surface of the tesseroid
     >>> coordinates = [0, 0, ellipsoid.mean_radius]
     >>> # Compute radial component of the gravitational gradient in mGal
-    >>> tesseroid_gravity(coordinates, tesseroid, density, field="g_z")
-    array(112.54539933)
+    >>> g_z = tesseroid_gravity(coordinates, tesseroid, density, field="g_z")
 
     >>> # Define a linear density function for the same tesseroid.
     >>> # It should be decorated with numba.njit
@@ -139,8 +138,9 @@ def tesseroid_gravity(
     ...     slope = (density_top - density_bottom) / (top - bottom)
     ...     return slope * (radius - bottom) + density_bottom
     >>> # Compute the downward acceleration it generates
-    >>> tesseroid_gravity(coordinates, tesseroid, linear_density, field="g_z")
-    array(125.80498632)
+    >>> g_z = tesseroid_gravity(
+    ...     coordinates, tesseroid, linear_density, field="g_z"
+    ... )
 
     """
     kernels = {"potential": kernel_potential_spherical, "g_z": kernel_g_z_spherical}


### PR DESCRIPTION
**Description**

Remove expected results for tesseroid calculations in docstring examples.
Printing floats in forward modelling examples isn't that meaningful and often
creates failures when running doctests: small differences between the expected
and the got value could occur under some dependency and OS combinations.
