### PR TITLE
Discard prisms with no volume or zero density

### DIFF
--- a/harmonica/forward/prism.py
+++ b/harmonica/forward/prism.py
@@ -186,8 +186,6 @@ def _check_prisms(prisms):
         ``w``, ``e``, ``s``, ``n``, ``bottom``, ``top``.
         The array must have the following shape: (``n_prisms``, 6), where
         ``n_prisms`` is the total number of prisms.
-        This array of prisms must have valid boundaries.
-        Run ``_check_prisms`` before.
     """
     west, east, south, north, bottom, top = tuple(prisms[:, i] for i in range(6))
     err_msg = "Invalid prism or prisms. "

--- a/harmonica/tests/test_prism.py
+++ b/harmonica/tests/test_prism.py
@@ -21,10 +21,10 @@ except ImportError:
 
 from ..forward.prism import (
     _check_prisms,
+    _discard_null_prisms,
     prism_gravity,
     safe_atan2,
     safe_log,
-    _discard_null_prisms,
 )
 from ..gravity_corrections import bouguer_correction
 from .utils import run_only_with_numba


### PR DESCRIPTION
Discard null prisms before passing them to the forward modelling
functions. A null prism is the one that has either zero volume or zero
density. Since they don't contribute to the generated field, we can save
some computation time by discarding them.

**Relevant issues/PRs:**

Related to #65 (@aguspesce noticed some zero division errors when passing zero volume tesseroids to the forward model computation).
