### PR TITLE
Add a function to ignore the tesseroid with zero density or volume

### DIFF
--- a/harmonica/forward/_tesseroid_utils.py
+++ b/harmonica/forward/_tesseroid_utils.py
@@ -521,9 +521,7 @@ def _discard_null_tesseroids(tesseroids, density):
     null_tesseroids = (lon_w == lon_e) | (lat_s == lat_n) | (bottom == top)
     # Mark prisms with zero density as null prisms
     null_tesseroids[density == 0] = True
-    print(null_tesseroids)
     # Keep only non null prisms
     tesseroids = tesseroids[np.logical_not(null_tesseroids), :]
-    print(tesseroids)
     density = density[np.logical_not(null_tesseroids)]
     return tesseroids, density

--- a/harmonica/forward/_tesseroid_utils.py
+++ b/harmonica/forward/_tesseroid_utils.py
@@ -500,7 +500,8 @@ def _discard_null_tesseroids(tesseroids, density):
     Parameters
     ----------
     tesseroids : 2d-array
-        Array containing the boundaries of the tesserois in the following order:
+        Array containing the boundaries of the tesserois in the following
+        order:
         ``longitude_w``. ``longitude_e``, ``latitude_s``, ``latitude_n``,
         ``bottom``, ``top`` under geocentric spherical coordinate system.
     density : 1d-array
@@ -510,8 +511,8 @@ def _discard_null_tesseroids(tesseroids, density):
     Returns
     -------
     tesseroids : 2d-array
-        A copy of the ``tesseroids`` array that doesn't include the null tesseroids
-    (tesseroid with zero density or zero volume).
+        A copy of the ``tesseroids`` array that doesn't include the null
+        tesseroids (tesseroid with zero density or zero volume).
     density : 1d-array
         A copy of the ``density`` array that doesn't include the density values
         for the null tesseroids (tesseroid with zero density or zero volume).

--- a/harmonica/forward/_tesseroid_utils.py
+++ b/harmonica/forward/_tesseroid_utils.py
@@ -501,9 +501,8 @@ def _discard_null_tesseroids(tesseroids, density):
     ----------
     tesseroids : 2d-array
         Array containing the boundaries of the tesserois in the following
-        order:
-        ``longitude_w``. ``longitude_e``, ``latitude_s``, ``latitude_n``,
-        ``bottom``, ``top`` under geocentric spherical coordinate system.
+        order: ``west``, ``east``, ``south``, ``north``, ``bottom``, ``top``
+        defined in a geocentric spherical coordinate system.
     density : 1d-array
         Array containing the density of each tesseroid in kg/m^3. Must have the
         same size as the number of tesseroids.
@@ -512,14 +511,14 @@ def _discard_null_tesseroids(tesseroids, density):
     -------
     tesseroids : 2d-array
         A copy of the ``tesseroids`` array that doesn't include the null
-        tesseroids (tesseroid with zero density or zero volume).
+        tesseroids (tesseroids with zero density or zero volume).
     density : 1d-array
         A copy of the ``density`` array that doesn't include the density values
         for the null tesseroids (tesseroid with zero density or zero volume).
     """
-    lon_w, lon_e, lat_s, lat_n, bottom, top = tuple(tesseroids[:, i] for i in range(6))
+    west, east, south, north, bottom, top = tuple(tesseroids[:, i] for i in range(6))
     # Mark prisms with zero volume as null prisms
-    null_tesseroids = (lon_w == lon_e) | (lat_s == lat_n) | (bottom == top)
+    null_tesseroids = (west == east) | (south == north) | (bottom == top)
     # Mark prisms with zero density as null prisms
     null_tesseroids[density == 0] = True
     # Keep only non null prisms

--- a/harmonica/forward/_tesseroid_utils.py
+++ b/harmonica/forward/_tesseroid_utils.py
@@ -491,3 +491,39 @@ def _longitude_continuity(tesseroids):
     east[tess_to_be_changed] = ((east[tess_to_be_changed] + 180) % 360) - 180
     west[tess_to_be_changed] = ((west[tess_to_be_changed] + 180) % 360) - 180
     return tesseroids
+
+
+def _discard_null_tesseroids(tesseroids, density):
+    """
+    Discard tesseroid with zero volume or zero density
+
+    Parameters
+    ----------
+    tesseroids : 2d-array
+        Array containing the boundaries of the tesserois in the following order:
+        ``longitude_w``. ``longitude_e``, ``latitude_s``, ``latitude_n``,
+        ``bottom``, ``top`` under geocentric spherical coordinate system.
+    density : 1d-array
+        Array containing the density of each tesseroid in kg/m^3. Must have the
+        same size as the number of tesseroids.
+
+    Returns
+    -------
+    tesseroids : 2d-array
+        A copy of the ``tesseroids`` array that doesn't include the null tesseroids
+    (tesseroid with zero density or zero volume).
+    density : 1d-array
+        A copy of the ``density`` array that doesn't include the density values
+        for the null tesseroids (tesseroid with zero density or zero volume).
+    """
+    lon_w, lon_e, lat_s, lat_n, bottom, top = tuple(tesseroids[:, i] for i in range(6))
+    # Mark prisms with zero volume as null prisms
+    null_tesseroids = (lon_w == lon_e) | (lat_s == lat_n) | (bottom == top)
+    # Mark prisms with zero density as null prisms
+    null_tesseroids[density == 0] = True
+    print(null_tesseroids)
+    # Keep only non null prisms
+    tesseroids = tesseroids[np.logical_not(null_tesseroids), :]
+    print(tesseroids)
+    density = density[np.logical_not(null_tesseroids)]
+    return tesseroids, density

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -17,6 +17,7 @@ from ._tesseroid_utils import (
     _check_tesseroids,
     gauss_legendre_quadrature,
     glq_nodes_weights,
+    _discard_null_tesseroids,
 )
 from ._tesseroid_variable_density import (
     density_based_discretization,
@@ -167,6 +168,10 @@ def tesseroid_gravity(
                 "Number of elements in density ({}) ".format(density.size)
                 + "mismatch the number of tesseroids ({})".format(tesseroids.shape[0])
             )
+        # Discard null tesseroids (zero density or zero volume)
+        tesseroids, density = _discard_null_tesseroids(tesseroids, density)
+        print("Tesseroids", tesseroids.shape)
+        print("density", density.shape)
     # Get GLQ unscaled nodes, weights and number of nodes for each small
     # tesseroid
     glq_nodes, glq_weights = glq_nodes_weights(GLQ_DEGREES)

--- a/harmonica/forward/tesseroid.py
+++ b/harmonica/forward/tesseroid.py
@@ -15,9 +15,9 @@ from ._tesseroid_utils import (
     _adaptive_discretization,
     _check_points_outside_tesseroids,
     _check_tesseroids,
+    _discard_null_tesseroids,
     gauss_legendre_quadrature,
     glq_nodes_weights,
-    _discard_null_tesseroids,
 )
 from ._tesseroid_variable_density import (
     density_based_discretization,
@@ -170,8 +170,6 @@ def tesseroid_gravity(
             )
         # Discard null tesseroids (zero density or zero volume)
         tesseroids, density = _discard_null_tesseroids(tesseroids, density)
-        print("Tesseroids", tesseroids.shape)
-        print("density", density.shape)
     # Get GLQ unscaled nodes, weights and number of nodes for each small
     # tesseroid
     glq_nodes, glq_weights = glq_nodes_weights(GLQ_DEGREES)

--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -276,12 +276,11 @@ def test_discard_null_tesseroids():
             [-10, -5, 5, 5, bottom, top],  # no volume due to noting boundaries
             [-5, 0, -10, -5, top, top],  # no volume due to radial boundaries
             [-5, 0, -5, 0, bottom, top],  # ok tesseroid
-            [-5, -5, 5, 5, top, top],  # no vlolume due to multiple boundaries
+            [-5, -5, 5, 5, top, top],  # no volume due to multiple boundaries
             [-5, 0, 5, 10, bottom, top],  # ok tesseroid
         ]
     )
-    densities = np.array(1000 * np.ones(len(tesseroids)))
-    densities[1] = 0.0
+    densities = np.array([2400, 0, 2500, 2600, 2700, 2800, 2900, 3000])
     tesseroids, densities = _discard_null_tesseroids(tesseroids, densities)
     npt.assert_allclose(
         tesseroids,
@@ -293,7 +292,7 @@ def test_discard_null_tesseroids():
             ]
         ),
     )
-    npt.assert_allclose(densities, np.array([1000, 1000, 1000]))
+    npt.assert_allclose(densities, np.array([2400, 2800, 3000]))
 
 
 # --------------------------------------

--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -15,6 +15,7 @@ from verde import grid_coordinates
 
 from ..constants import GRAVITATIONAL_CONST
 from ..forward._tesseroid_utils import (
+    _discard_null_tesseroids,
     _distance_tesseroid_point,
     _longitude_continuity,
     _split_tesseroid,
@@ -257,6 +258,42 @@ def test_stack_overflow_on_adaptive_discretization():
         _adaptive_discretization(
             coordinates, tesseroid, distance_size_ratio, stack, small_tesseroids
         )
+
+
+def test_discard_null_tesseroids():
+    """
+    Test if discarding invalid tesseroid works as expected
+    """
+    # Define a set of sample tesseroids including invalid ones
+    ellipsoid = boule.WGS84
+    top = ellipsoid.mean_radius
+    bottom = top - 1e3
+    tesseroids = np.array(
+        [
+            [-10, -5, -10, -5, bottom, top],  # ok tesseroid
+            [-10, -5, -5, 0, bottom, top],  # ok tesseroid (will set zero density)
+            [-10, -10, 0, 5, bottom, top],  # no volume due to easting boundaries
+            [-10, -5, 5, 5, bottom, top],  # no volume due to noting boundaries
+            [-5, 0, -10, -5, top, top],  # no volume due to radial boundaries
+            [-5, 0, -5, 0, bottom, top],  # ok tesseroid
+            [-5, -5, 5, 5, top, top],  # no vlolume due to multiple boundaries
+            [-5, 0, 5, 10, bottom, top],  # ok tesseroid
+        ]
+    )
+    densities = np.array(1000 * np.ones(len(tesseroids)))
+    densities[1] = 0.0
+    tesseroids, densities = _discard_null_tesseroids(tesseroids, densities)
+    npt.assert_allclose(
+        tesseroids,
+        np.array(
+            [
+                [-10, -5, -10, -5, bottom, top],
+                [-5, 0, -5, 0, bottom, top],
+                [-5, 0, 5, 10, bottom, top],
+            ]
+        ),
+    )
+    npt.assert_allclose(densities, np.array([1000, 1000, 1000]))
 
 
 # --------------------------------------


### PR DESCRIPTION
When I am working on `tesseroid_layer` function, I had an error for tesseroid with zero volume. 
So I add a new checked in `tesseroid_gravity` that ignore the tesseroid with zero density or zero volume 
