### PR TITLE
Fix equivalent sources figures in gallery examples

### DIFF
--- a/examples/equivalent_sources/block_averaged_sources.py
+++ b/examples/equivalent_sources/block_averaged_sources.py
@@ -82,6 +82,7 @@ print("R² score:", eqs.score(coordinates, data.total_field_anomaly_nt))
 # requires the height of the grid points (upward coordinate). By passing in
 # 1500 m, we're effectively upward-continuing the data (mean flight height is
 # 500 m).
+region = vd.get_region(coordinates)  # get the region boundaries
 grid_coords = vd.grid_coordinates(region=region, spacing=500, extra_coords=1500)
 grid = eqs.grid(coordinates=grid_coords, data_names=["magnetic_anomaly"])
 

--- a/examples/equivalent_sources/cartesian.py
+++ b/examples/equivalent_sources/cartesian.py
@@ -71,6 +71,7 @@ print("R² score:", eqs.score(coordinates, data.total_field_anomaly_nt))
 # requires the height of the grid points (upward coordinate). By passing in
 # 1500 m, we're effectively upward-continuing the data (mean flight height is
 # 500 m).
+region = vd.get_region(coordinates)  # get the region boundaries
 grid_coords = vd.grid_coordinates(region=region, spacing=500, extra_coords=1500)
 grid = eqs.grid(coordinates=grid_coords, data_names=["magnetic_anomaly"])
 

--- a/examples/equivalent_sources/gradient_boosted.py
+++ b/examples/equivalent_sources/gradient_boosted.py
@@ -91,6 +91,7 @@ print("R² score:", eqs_gb.score(coordinates, data.gravity_disturbance))
 # Interpolate data on a regular grid with 2 km spacing. The interpolation
 # requires the height of the grid points (upward coordinate). By passing in
 # 1000 m, we're effectively upward-continuing the data.
+region = vd.get_region(coordinates)  # get the region boundaries
 grid_coords = vd.grid_coordinates(region=region, spacing=2e3, extra_coords=1000)
 grid = eqs_gb.grid(coordinates=grid_coords, data_names="gravity_disturbance")
 print(grid)


### PR DESCRIPTION
Hi Fatiando team!

First I'm happy to see that the upward continuation is now live in v0.5.0. I was using it until now with the old Fatiando!

This PR is related to a documentation issue and specifically to the example in the [equivalent source page](https://www.fatiando.org/harmonica/latest/gallery/equivalent_sources/gradient_boosted.html#sphx-glr-gallery-equivalent-sources-gradient-boosted-py)

**Issue**: the plot of the upward continued data is empty.

**Small tweak**: add the `region = vd.get_region(coordinates)` line to the examples. This allows getting the right coordinates to grid.

Looking forward to using the upward continuation feature!