### PR TITLE
Add tesseroid_layer to the API reference

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -60,7 +60,9 @@ Forward modelling
     prism_gravity
     tesseroid_gravity
     prism_layer
+    tesseroid_layer
     DatasetAccessorPrismLayer
+    DatasetAccessorTesseroidLayer
 
 Isostatic Moho
 --------------


### PR DESCRIPTION
Add the new `tesseroid_layer` function to the API reference along with the
`DatasetAccesorTesseroidLayer` class.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

Related to #316
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
