### PR TITLE
Replace setup.py with PyPA "build"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          make build
           echo ""
           echo "Generated files:"
           ls -lh dist/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          build
           echo ""
           echo "Generated files:"
           ls -lh dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          build
           echo ""
           echo "Generated files:"
           ls -lh dist/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT=harmonica
 TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 NUMBATEST_ARGS=--doctest-modules -v --pyargs -m use_numba
-STYLE_CHECK_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py tools
+STYLE_CHECK_FILES=$(PROJECT) examples data/examples doc/conf.py tools
 
 help:
 	@echo "Commands:"
@@ -12,11 +12,17 @@ help:
 	@echo "  test      run the test suite (including doctests) and report coverage"
 	@echo "  format    run isort and black to automatically format the code"
 	@echo "  check     run code style and quality checks (black, isort and flake8)"
+	@echo "  build     build source and wheel distributions"
 	@echo "  clean     clean up build and generated files"
 	@echo ""
 
+.PHONY: build, install, test, test_coverage, test_numba, format, check, black, black-check, isort, isort-check, license, license-check, flake8, clean
+
+build:
+	python -m build .
+
 install:
-	pip install --no-deps -e .
+	python -m pip install --no-deps -e .
 
 test: test_coverage test_numba
 

--- a/env/requirements-build.txt
+++ b/env/requirements-build.txt
@@ -1,5 +1,3 @@
 # Requirements to build and check distributions
-setuptools>=45
-setuptools_scm>=6.2
+build
 twine
-wheel

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,7 @@ dependencies:
   - python==3.10.*
   - pip
   # Build
-  - setuptools>=45
-  - setuptools_scm>=6.2
-  - wheel
+  - build
   - twine
   # Run-time
   - numpy>=1.19


### PR DESCRIPTION
Use the build package to generate source and wheel distributions.
This means we can remove the setup.py file entirely since it's not
needed. Update the GitHub Actions workflows to match.

**Relevant issues/PRs:**

Inspired in https://github.com/fatiando/verde/pull/371
