### PR TITLE
Install flake8-unused-arguments from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -52,11 +52,9 @@ dependencies:
   - flake8-mutable==1.2.*
   - flake8-rst-docstrings==0.3.*
   - flake8-simplify==0.19.*
+  - flake8-unused-arguments==0.0.12
   - pep8-naming==0.13.*
   - pip:
-      # Install flake8-unused-arguments through pip
-      # (not available through conda yet)
-      - flake8-unused-arguments==0.0.12
       # Install numba_progress through pip
       # (not available through conda yet)
       - numba_progress


### PR DESCRIPTION
Update `environment.yml` so `flake8-unused-arguments` gets installed
from conda-forge rather than from PyPI.
