### PR TITLE
Use Verde's CheckerBoard class from synthetic module

### DIFF
--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -53,7 +53,7 @@ def fixture_masses(region, points):
     """
     Return the masses some sample point masses
     """
-    return vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    return vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
 
 
 @pytest.fixture(name="data")

--- a/harmonica/tests/test_eq_sources_spherical.py
+++ b/harmonica/tests/test_eq_sources_spherical.py
@@ -40,7 +40,7 @@ def fixture_masses(region, points):
     """
     Return the masses some sample point masses
     """
-    return vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    return vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
 
 
 @pytest.fixture(name="coordinates_small")
@@ -77,7 +77,7 @@ def test_equivalent_sources_spherical():
     points = vd.grid_coordinates(
         region=region, shape=(6, 6), extra_coords=radius - 500e3
     )
-    masses = vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    masses = vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
     # Define a set of observation points
     coordinates = vd.grid_coordinates(
         region=region, shape=(40, 40), extra_coords=radius
@@ -118,7 +118,7 @@ def test_equivalent_sources_small_data_spherical():
     points = vd.grid_coordinates(
         region=region, shape=(6, 6), extra_coords=radius - 500e3
     )
-    masses = vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    masses = vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
     # Define a set of observation points
     coordinates = vd.grid_coordinates(region=region, shape=(8, 8), extra_coords=radius)
     # Get synthetic data
@@ -162,7 +162,7 @@ def test_equivalent_sources_custom_points_spherical():
     points = vd.grid_coordinates(
         region=region, shape=(6, 6), extra_coords=radius - 500e3
     )
-    masses = vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    masses = vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
     # Define a set of observation points
     coordinates = vd.grid_coordinates(region=region, shape=(5, 5), extra_coords=radius)
     # Get synthetic data
@@ -222,7 +222,7 @@ def test_equivalent_sources_spherical_parallel():
     points = vd.grid_coordinates(
         region=region, shape=(6, 6), extra_coords=radius - 500e3
     )
-    masses = vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    masses = vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
     # Define a set of observation points
     coordinates = vd.grid_coordinates(
         region=region, shape=(40, 40), extra_coords=radius

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -48,7 +48,7 @@ def fixture_masses(region, points):
     """
     Return the masses some sample point masses
     """
-    return vd.datasets.CheckerBoard(amplitude=1e13, region=region).predict(points)
+    return vd.synthetic.CheckerBoard(amplitude=1e13, region=region).predict(points)
 
 
 @pytest.fixture(name="data")


### PR DESCRIPTION
Instead of using the marked-as-deprecated `verde.datasets.CheckerBoard` class, use the new `verde.synthetic.CheckerBoard` on gallery and user guide examples.