### PR TITLE
Disable tar.bz2 only in setup-miniconda Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,8 +68,11 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           channels: conda-forge,defaults
-          # Needed for caching
-          use-only-tar-bz2: true
+          # Allow mamba to use other than tar.bz2
+          # (otherwise it cannot find latest versions that
+          # don't use tar-bz2 files, see
+          # https://github.com/conda-incubator/setup-miniconda/issues/267)
+          use-only-tar-bz2: false
 
       - name: Collect requirements
         run: |

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -7,7 +7,7 @@ sphinx-copybutton==0.5.*
 jupyter-sphinx==0.3.*
 boule
 pyproj
-ensaio
+ensaio>=0.5.*
 netcdf4
 matplotlib
 pyvista


### PR DESCRIPTION
Configure the `setup-miniconda` GitHub action with `use-only-tar-bz2: false`, allowing mamba to use files other than `.tar.bz2`. Otherwise mamba cannot install latest versions of some packages that aren't provided as those files. Pin Ensaio to greater than v0.5. This version of Ensaio couldn't be installed before this change.
