### PR TITLE
Make "publish" job in Actions to need the "build" as finished

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Upload HTML documentation as an artifact
         # Only if not a pull request
         if: success() && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs-${{ github.sha }}
           path: doc/_build/html
@@ -148,7 +148,7 @@ jobs:
 
       # Fetch the built docs from the "build" job
       - name: Download HTML documentation artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docs-${{ github.sha }}
           path: doc/_build/html

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Upload archives as artifacts
         # Only if not a pull request
         if: success() && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pypi-${{ github.sha }}
           path: dist
@@ -100,7 +100,7 @@ jobs:
           persist-credentials: false
 
       - name: Download built source and wheel packages
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: pypi-${{ github.sha }}
           path: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -88,6 +88,7 @@ jobs:
   # Publish built wheels and source archives to PyPI and test PyPI
   publish:
     runs-on: ubuntu-latest
+    needs: build
     # Only publish from the origin repository, not forks
     if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
 


### PR DESCRIPTION
The `publish` job now requires that the `build` job should be finished before starting. This solves the issue of the `publish` job not finding the uploaded artifact. Update the versions of the `upload-artifacts` and `download-artifacts` to v3 in `pypi.yml`.
