### PR TITLE
Drop null prisms when converting a prism layer to pyvista

### DIFF
--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -477,7 +477,9 @@ class DatasetAccessorPrismLayer:
         Parameters
         ----------
         drop_null_prisms : bool (optional)
-            If True, prisms with zero volume are not going to be converted.
+            If True, prisms with zero volume are not going to be included in
+            the :class:`pyvista.UnstructuredGrid`.
+            If False, every prism in the layer will be included.
             Default False.
 
         Returns

--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -470,7 +470,7 @@ class DatasetAccessorPrismLayer:
         top = self._obj.top.values[indices]
         return west, east, south, north, bottom, top
 
-    def to_pyvista(self, drop_null_prisms=False):
+    def to_pyvista(self, drop_null_prisms=True):
         """
         Return a pyvista UnstructuredGrid to plot the PrismLayer
 

--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -470,9 +470,15 @@ class DatasetAccessorPrismLayer:
         top = self._obj.top.values[indices]
         return west, east, south, north, bottom, top
 
-    def to_pyvista(self):
+    def to_pyvista(self, drop_null_prisms=False):
         """
         Return a pyvista UnstructuredGrid to plot the PrismLayer
+
+        Parameters
+        ----------
+        drop_null_prisms : bool (optional)
+            If True, prisms with zero volume are not going to be converted.
+            Default False.
 
         Returns
         -------
@@ -481,10 +487,18 @@ class DatasetAccessorPrismLayer:
             layer as a hexahedron along with their properties.
         """
         prisms = self._to_prisms()
+        null_prisms = np.zeros_like(prisms[:, 0], dtype=bool)
+        if drop_null_prisms:
+            bottom, top = prisms[:, -2], prisms[:, -1]
+            null_prisms = top == bottom
+            prisms = prisms[np.logical_not(null_prisms)]
+        # Define properties
         properties = None
         if self._obj.data_vars:
             properties = {
-                data_var: np.asarray(self._obj[data_var]).ravel()
+                data_var: np.asarray(self._obj[data_var]).ravel()[
+                    np.logical_not(null_prisms)
+                ]
                 for data_var in self._obj.data_vars
             }
         return prism_to_pyvista(prisms, properties=properties)

--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -477,8 +477,9 @@ class DatasetAccessorPrismLayer:
         Parameters
         ----------
         drop_null_prisms : bool (optional)
-            If True, prisms with zero volume are not going to be included in
-            the :class:`pyvista.UnstructuredGrid`.
+            If True, prisms with zero volume or with any :class:`numpy.nan` as
+            their top or bottom boundaries won't be included in the
+            :class:`pyvista.UnstructuredGrid`.
             If False, every prism in the layer will be included.
             Default False.
 
@@ -492,7 +493,7 @@ class DatasetAccessorPrismLayer:
         null_prisms = np.zeros_like(prisms[:, 0], dtype=bool)
         if drop_null_prisms:
             bottom, top = prisms[:, -2], prisms[:, -1]
-            null_prisms = top == bottom
+            null_prisms = (top == bottom) | (np.isnan(top)) | (np.isnan(bottom))
             prisms = prisms[np.logical_not(null_prisms)]
         # Define properties
         properties = None

--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -481,7 +481,7 @@ class DatasetAccessorPrismLayer:
             their top or bottom boundaries won't be included in the
             :class:`pyvista.UnstructuredGrid`.
             If False, every prism in the layer will be included.
-            Default False.
+            Default True.
 
         Returns
         -------

--- a/harmonica/tests/test_prism_layer.py
+++ b/harmonica/tests/test_prism_layer.py
@@ -444,10 +444,12 @@ def test_to_pyvista_zero_volume(dummy_layer):
     # Assign zero volume to some prisms
     layer.top.values[0, 0] = layer.bottom.values[0, 0]
     layer.top.values[2, 1] = layer.bottom.values[2, 1]
+    layer.top.values[3, 2] = np.nan
+    layer.bottom.values[3, 3] = np.nan
     # Convert the layer to pyvista UnstructuredGrid
     pv_grid = layer.prism_layer.to_pyvista(drop_null_prisms=True)
     # Check properties of the pyvista grid
-    expected_n_prisms = 20 - 2
+    expected_n_prisms = 20 - 4
     assert pv_grid.n_cells == expected_n_prisms
     assert pv_grid.n_points == expected_n_prisms * 8
     assert pv_grid.n_arrays == 1


### PR DESCRIPTION
Add an optional `drop_null_prisms` flag to the prism layer `to_pyvista()` method that ditches the prisms that have zero volume or `nan` values in their top or bottom boundaries. These null prisms won't be included in the PyVista Unstructured grid. By default the flag is set to `True`. Add a new test for this new feature.

**Relevant issues/PRs:**

Fixes #392
