### PR TITLE
Add ipykernel as requiement for building the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -115,9 +115,6 @@ jobs:
 
       - name: Build the documentation
         run: |
-          # Print available jupyter clients
-          echo "Jupyter clients"
-          jupyter kernelspec list
           # Install xvfb and run some commands to allow pyvista to run on
           # a headless system.
           sudo apt-get install xvfb

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -115,6 +115,9 @@ jobs:
 
       - name: Build the documentation
         run: |
+          # Print available jupyter clients
+          echo "Jupyter clients"
+          jupyter kernelspec list
           # Install xvfb and run some commands to allow pyvista to run on
           # a headless system.
           sudo apt-get install xvfb

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -16,3 +16,4 @@ pygmt==0.7.*
 gmt==6.4.*
 gdal==3.5.*
 nbformat==5.7.3
+jupyter_client==8.0.3

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -15,4 +15,4 @@ vtk>=9
 pygmt==0.7.*
 gmt==6.4.*
 gdal==3.5.*
-nbformat
+nbformat==5.7.3

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -15,5 +15,4 @@ vtk>=9
 pygmt==0.7.*
 gmt==6.4.*
 gdal==3.5.*
-nbformat==5.7.3
-jupyter_client==8.0.3
+ipykernel

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -15,3 +15,4 @@ vtk>=9
 pygmt==0.7.*
 gmt==6.4.*
 gdal==3.5.*
+nbformat


### PR DESCRIPTION
Fixes issue with GitHub Actions not being able to build the documentation due to missing `python3` kernel. Explicitly installing `ipykernel` solves the problem.

**Relevant issues/PRs:**

Problem first encountered in #393 
