### PR TITLE
Update gravity_disturbance_topofree.py

### DIFF
--- a/examples/gravity_disturbance_topofree.py
+++ b/examples/gravity_disturbance_topofree.py
@@ -61,7 +61,7 @@ disturbance_topofree = disturbance - bouguer
 # Make a plot of data using PyGMT
 fig = pygmt.Figure()
 
-pygmt.grd2cpt(grid=disturbance_topofree, cmap="vik", continuous=True)
+pygmt.grd2cpt(grid=disturbance_topofree, cmap="vik+h0", continuous=True)
 
 title = "Topography-free (Bouguer) gravity disturbance of the Earth"
 


### PR DESCRIPTION
At the beginnig of the scripts says: "The gravity disturbance is the observed gravity minus the normal gravity (boule.Ellipsoid.normal_gravity). The signal that is left is assumed to be due to the differences between the actual Earth and the reference ellipsoid." So, the value 0 has a special meaning. 

But, in the figure the hinge (white color) of the CPT is around 100. I think that it should be in 0.

To fix it, I propose to force the hinge at 0 (+h0).

