### PR TITLE
Fail CI if codecov upload fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           env_vars: OS,PYTHON,DEPENDENCIES
-          # Don't mark the job as failed if the upload fails for some reason.
-          # It does sometimes but shouldn't be the reason for running
-          # everything again unless something else is broken.
-          fail_ci_if_error: false
+          # Fail the job so we know coverage isn't being updated. Otherwise it
+          # can silently drop and we won't know.
+          fail_ci_if_error: true


### PR DESCRIPTION
Let the CI job fail if the codecov upload fails. Otherwise it could stop and we wouldn't know.

**Relevant issues/PRs:**

Inspired by https://github.com/fatiando/verde/pull/409
