### PR TITLE
Improve coordinates description in forward functions

### DIFF
--- a/harmonica/_forward/point.py
+++ b/harmonica/_forward/point.py
@@ -135,8 +135,8 @@ def point_gravity(
 
     Parameters
     ----------
-    coordinates : list or array
-        List or array containing the coordinates of computation points in the
+    coordinates : list of arrays
+        List of arrays containing the coordinates of computation points in the
         following order: ``easting``, ``northing`` and ``upward`` (if
         coordinates given in Cartesian coordinates), or ``longitude``,
         ``latitude`` and ``radius`` (if given on a spherical geocentric

--- a/harmonica/_forward/prism.py
+++ b/harmonica/_forward/prism.py
@@ -52,10 +52,10 @@ def prism_gravity(
 
     Parameters
     ----------
-    coordinates : list or 1d-array
-        List or array containing ``easting``, ``northing`` and ``upward`` of
-        the computation points defined on a Cartesian coordinate system.
-        All coordinates should be in meters.
+    coordinates : list of arrays
+        List of arrays containing the ``easting``, ``northing`` and ``upward``
+        coordinates of the computation points defined on a Cartesian coordinate
+        system. All coordinates should be in meters.
     prisms : list, 1d-array, or 2d-array
         List or array containing the coordinates of the prism(s) in the
         following order:

--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -329,10 +329,10 @@ class DatasetAccessorPrismLayer:
 
         Parameters
         ----------
-        coordinates : list or 1d-array
-            List or array containing ``easting``, ``northing`` and ``upward``
-            of the computation points defined on a Cartesian coordinate system.
-            All coordinates should be in meters.
+        coordinates : list of arrays
+            List of arrays containing the ``easting``, ``northing`` and
+            ``upward`` coordinates of the computation points defined on
+            a Cartesian coordinate system. All coordinates should be in meters.
         field : str
             Gravitational field that wants to be computed.
             The available fields are:

--- a/harmonica/_forward/tesseroid.py
+++ b/harmonica/_forward/tesseroid.py
@@ -53,13 +53,12 @@ def tesseroid_gravity(
 
     Parameters
     ----------
-    coordinates : list or 1d-array
-        List or array containing ``longitude``, ``latitude`` and ``radius`` of
-        the computation points defined on a spherical geocentric coordinate
-        system.
-        Both ``longitude`` and ``latitude`` should be in degrees and ``radius``
-        in meters.
-    tesseroids : list or 1d-array
+    coordinates : list of arrays
+        List of arrays containing the ``longitude``, ``latitude`` and
+        ``radius`` coordinates of the computation points, defined on
+        a spherical geocentric coordinate system. Both ``longitude`` and
+        ``latitude`` should be in degrees and ``radius`` in meters.
+    tesseroids : list or 2d-array
         List or array containing the coordinates of the tesseroid:
         ``w``, ``e``, ``s``, ``n``, ``bottom``, ``top`` under a geocentric
         spherical coordinate system.

--- a/harmonica/_forward/tesseroid_layer.py
+++ b/harmonica/_forward/tesseroid_layer.py
@@ -256,10 +256,11 @@ class DatasetAccessorTesseroidLayer:
 
         Parameters
         ----------
-        coordinates : list or 1d-array
-            List of array containing ``latitude``, ``longitude`` and ``upward``
-            of the computation points defined on a spherical coordinates
-            system. ``upward`` coordinate should be in meters.
+        coordinates : list of arrays
+            List of arrays containing the ``longitude``, ``latitude`` and
+            ``radius`` coordinates of the computation points, defined on
+            a spherical geocentric coordinate system. Both ``longitude`` and
+            ``latitude`` should be in degrees and ``radius`` in meters.
         field : str
             Gravitational field that wants to be computed.
             The variable fields are:


### PR DESCRIPTION
Improve the description of coordinates in several forward modelling functions (prisms, tesseroids and points). Fix wrong dimension of the `coordinates` as an array, and improve writing style. Fix wrong order of coordinates in `tesseroid_layer`.