### PR TITLE
Fix style for class names in changes.rst

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,7 @@ Version 0.6.0
 
 Deprecations:
 
-- Deprecate `EQLHarmonic` and `EQLHarmonicSpherical` classes (`#366 <https://github.com/fatiando/harmonica/pull/366>`__)
+- Deprecate ``EQLHarmonic`` and ``EQLHarmonicSpherical`` classes (`#366 <https://github.com/fatiando/harmonica/pull/366>`__)
 - Deprecate ``isostasy_airy`` function (`#379 <https://github.com/fatiando/harmonica/pull/379>`__)
 - Deprecate the synthetic and dataset modules (`#380 <https://github.com/fatiando/harmonica/pull/380>`__)
 


### PR DESCRIPTION
Use double backticks when mentioning deprecated equivalent sources classes in `changes.rst`.