### PR TITLE
Fix docs not building: install trame

### DIFF
--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -16,3 +16,4 @@ pygmt==0.7.*
 gmt==6.4.*
 gdal==3.5.*
 ipykernel
+trame

--- a/environment.yml
+++ b/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - pygmt==0.7.*
   - gmt==6.4.*
   - gdal==3.5.*
+  - trame # needed by pyvista
   # Code style checks and autoformat
   - black==22.10.*
   - isort==5.10.*


### PR DESCRIPTION
Try to fix docs not building due to Pyvista complaining about lacking of `trame`.
