### PR TITLE
Fix prism and tesseroid layer in API Reference

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -85,6 +85,8 @@ Magnetic fields:
 Layers and meshes:
 
 .. autosummary::
+    :toctree: generated/
+
     prism_layer
     tesseroid_layer
     DatasetAccessorPrismLayer


### PR DESCRIPTION
Fix issue that wasn't generating the links to the `prism_layer` and `tesseroid_layer` functions in the API Reference.
