### PR TITLE
Update how to pip install dev version in install.rst

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -82,7 +82,7 @@ Installing the latest development version
 
 You can use ``pip`` to install the latest source from Github::
 
-    pip install https://github.com/fatiando/harmonica/archive/main.zip
+    pip install git+https://github.com/fatiando/harmonica
 
 Alternatively, you can clone the git repository locally and install from
 there::


### PR DESCRIPTION
Updated how to pip install the development version.  The previous version caused `error: subprocess-exited-with-error`. I have updated based on the suggestion in the error message which is also similar to the Verde documentation.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
