### PR TITLE
Bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -141,7 +141,7 @@ jobs:
 
       # Fetch the built docs from the "build" job
       - name: Download HTML documentation artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs-${{ github.sha }}
           path: doc/_build/html

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -101,7 +101,7 @@ jobs:
           persist-credentials: false
 
       - name: Download built source and wheel packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pypi-${{ github.sha }}
           path: dist


### PR DESCRIPTION
The v3 one fails to download artifacts from upload-artifact v4.

