### PR TITLE
Fix typo in user guide

### DIFF
--- a/doc/user_guide/equivalent_sources/block-averaged-eqs.rst
+++ b/doc/user_guide/equivalent_sources/block-averaged-eqs.rst
@@ -51,7 +51,7 @@ the data:
     data = data[inside]
     data
 
-And project the geographic coordiantes to plain Cartesian ones:
+And project the geographic coordinates to plain Cartesian ones:
 
 .. jupyter-execute::
 


### PR DESCRIPTION
Replace `coordiantes` for `coordinates`.
