### PR TITLE
Print xarray objects in user guide

### DIFF
--- a/doc/sg_execution_times.rst
+++ b/doc/sg_execution_times.rst
@@ -1,0 +1,85 @@
+
+:orphan:
+
+.. _sphx_glr_sg_execution_times:
+
+
+Computation times
+=================
+**00:00.000** total execution time for 17 files **from all galleries**:
+
+.. container::
+
+  .. raw:: html
+
+    <style scoped>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet" />
+    </style>
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script type="text/javascript" class="init">
+    $(document).ready( function () {
+        $('table.sg-datatable').DataTable({order: [[1, 'desc']]});
+    } );
+    </script>
+
+  .. list-table::
+   :header-rows: 1
+   :class: table table-striped sg-datatable
+
+   * - Example
+     - Time
+     - Mem (MB)
+   * - :ref:`sphx_glr_gallery_equivalent_sources_block_averaged_sources.py` (``../examples/equivalent_sources/block_averaged_sources.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_equivalent_sources_cartesian.py` (``../examples/equivalent_sources/cartesian.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_equivalent_sources_gradient_boosted.py` (``../examples/equivalent_sources/gradient_boosted.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_equivalent_sources_spherical.py` (``../examples/equivalent_sources/spherical.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_forward_point_gravity.py` (``../examples/forward/point_gravity.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_forward_prism_layer.py` (``../examples/forward/prism_layer.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_forward_prisms_topo_gravity.py` (``../examples/forward/prisms_topo_gravity.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_forward_tesseroid.py` (``../examples/forward/tesseroid.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_forward_tesseroid_layer.py` (``../examples/forward/tesseroid_layer.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_forward_tesseroid_variable_density.py` (``../examples/forward/tesseroid_variable_density.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_gravity_disturbance.py` (``../examples/gravity_disturbance.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_gravity_disturbance_topofree.py` (``../examples/gravity_disturbance_topofree.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_isostatic_moho_airy.py` (``../examples/isostatic_moho_airy.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_transformations_reduction_to_pole.py` (``../examples/transformations/reduction_to_pole.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_transformations_upward_continuation.py` (``../examples/transformations/upward_continuation.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_transformations_upward_derivative.py` (``../examples/transformations/upward_derivative.py``)
+     - 00:00.000
+     - 0.0
+   * - :ref:`sphx_glr_gallery_visualization_prism_layer_pyvista.py` (``../examples/visualization/prism_layer_pyvista.py``)
+     - 00:00.000
+     - 0.0

--- a/doc/user_guide/equivalent_sources/block-averaged-eqs.rst
+++ b/doc/user_guide/equivalent_sources/block-averaged-eqs.rst
@@ -170,7 +170,7 @@ we are efectivelly upward continuing the data.
         extra_coords=1500,
     )
     grid = eqs.grid(grid_coords, data_names=["magnetic_anomaly"])
-    grid
+    print(grid)
 
 
 .. jupyter-execute::

--- a/doc/user_guide/equivalent_sources/eq-sources-spherical.rst
+++ b/doc/user_guide/equivalent_sources/eq-sources-spherical.rst
@@ -133,7 +133,7 @@ Lastly we can generate a :class:`xarray.DataArray` using
         data_names=["gravity_disturbance"],
         extra_coords_names="upward",
     )
-    grid
+    print(grid)
 
 Since the data points don't cover the entire area, we might want to mask those
 grid points that are too far away from any data point:

--- a/doc/user_guide/equivalent_sources/gradient-boosted-eqs.rst
+++ b/doc/user_guide/equivalent_sources/gradient-boosted-eqs.rst
@@ -133,7 +133,7 @@ And then predict the field on a regular grid of computation points:
         extra_coords=2.5e3,
     )
     grid = eqs.grid(grid_coords, data_names=["gravity_disturbance"])
-    grid
+    print(grid)
 
 Since this particular dataset doesn't have a good coverage of the entire area,
 we might want to mask the output grid based on the distance to the closest data

--- a/doc/user_guide/equivalent_sources/index.rst
+++ b/doc/user_guide/equivalent_sources/index.rst
@@ -179,7 +179,7 @@ and use the equivalent sources to generate a gravity disturbance grid.
 
    # Grid the gravity disturbances
    grid = equivalent_sources.grid(grid_coords, data_names=["gravity_disturbance"])
-   grid
+   print(grid)
 
 And plot it
 

--- a/doc/user_guide/topographic_correction.rst
+++ b/doc/user_guide/topographic_correction.rst
@@ -147,7 +147,7 @@ We can download a global topography grid:
 
    fname = ensaio.fetch_southern_africa_topography(version=1)
    topography = xr.load_dataarray(fname)
-   topography
+   print(topography)
 
 And then crop it to a slightly larger region than the gravity observations:
 
@@ -160,7 +160,7 @@ And then crop it to a slightly larger region than the gravity observations:
        longitude=slice(region_pad[0], region_pad[1]),
        latitude=slice(region_pad[2], region_pad[3]),
    )
-   topography
+   print(topography)
 
 And project it to plain coordinates using :mod:`pyproj` and :mod:`verde`.
 We start by defining a Mercator projection:
@@ -176,7 +176,7 @@ And project the grid using :func:`verde.project_grid`:
 .. jupyter-execute::
 
    topography_proj = vd.project_grid(topography, projection, method="nearest")
-   topography_proj
+   print(topography_proj)
 
 .. tip::
 
@@ -204,7 +204,7 @@ the density of the upper crust.
        reference=0,
        properties={"density": density},
    )
-   prisms
+   print(prisms)
 
 Now we need to compute the gravitational effect of these prisms on every
 observation point. We can do it through the

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -20,7 +20,7 @@ We can load the data file using :mod:`xarray`:
 
     fname = ensaio.fetch_lightning_creek_magnetic(version=1)
     magnetic_grid = xr.load_dataarray(fname)
-    magnetic_grid
+    print(magnetic_grid)
 
 And plot it:
 
@@ -64,7 +64,7 @@ needed by the :func:`xrft.pad` function):
 
     magnetic_grid_no_height = magnetic_grid.drop_vars("height")
     magnetic_grid_padded = xrft.pad(magnetic_grid_no_height, pad_width)
-    magnetic_grid_padded
+    print(magnetic_grid_padded)
 
 .. jupyter-execute::
 
@@ -89,7 +89,7 @@ magnetic anomaly grid using the :func:`harmonica.derivative_upward` function:
     import harmonica as hm
 
     deriv_upward = hm.derivative_upward(magnetic_grid_padded)
-    deriv_upward
+    print(deriv_upward)
 
 This grid includes all the padding we added to the original magnetic grid, so
 we better unpad it using :func:`xrft.unpad`:
@@ -97,7 +97,7 @@ we better unpad it using :func:`xrft.unpad`:
 .. jupyter-execute::
 
     deriv_upward = xrft.unpad(deriv_upward, pad_width)
-    deriv_upward
+    print(deriv_upward)
 
 And plot it:
 
@@ -121,12 +121,12 @@ functions.
 .. jupyter-execute::
 
     deriv_easting = hm.derivative_easting(magnetic_grid)
-    deriv_easting
+    print(deriv_easting)
 
 .. jupyter-execute::
 
     deriv_northing = hm.derivative_northing(magnetic_grid)
-    deriv_northing
+    print(deriv_northing)
 
 And plot them:
 
@@ -162,13 +162,13 @@ frequency domain:
 
     deriv_easting = hm.derivative_easting(magnetic_grid_padded, method="fft")
     deriv_easting = xrft.unpad(deriv_easting, pad_width)
-    deriv_easting
+    print(deriv_easting)
 
 .. jupyter-execute::
 
     deriv_northing = hm.derivative_northing(magnetic_grid_padded, method="fft")
     deriv_northing = xrft.unpad(deriv_northing, pad_width)
-    deriv_northing
+    print(deriv_northing)
 
 .. jupyter-execute::
 
@@ -222,7 +222,7 @@ we better unpad it using :func:`xrft.unpad`:
 .. jupyter-execute::
 
     upward_continued = xrft.unpad(upward_continued, pad_width)
-    upward_continued
+    print(upward_continued)
 
 And plot it:
 
@@ -274,7 +274,7 @@ remanence), then we can apply the reduction to the pole passing only the
 
     # Unpad the reduced to the pole grid
     rtp_grid = xrft.unpad(rtp_grid, pad_width)
-    rtp_grid
+    print(rtp_grid)
 
 And plot it:
 
@@ -305,7 +305,7 @@ magnetization vector of the sources, we can specify the
 
     # Unpad the reduced to the pole grid
     rtp_grid = xrft.unpad(rtp_grid, pad_width)
-    rtp_grid
+    print(rtp_grid)
 
 .. jupyter-execute::
 
@@ -357,11 +357,11 @@ And unpad them:
 
 .. jupyter-execute::
 
-    magnetic_low_freqs
+    print(magnetic_low_freqs)
 
 .. jupyter-execute::
 
-    magnetic_high_freqs
+    print(magnetic_high_freqs)
 
 Let's plot the results side by side:
 


### PR DESCRIPTION
Print `xarray.DataArray` and `xarray.Dataset` objects in the user guide pages instead of display them and letting Jupyter to render them as HTML objects. This is a patch to output cells not rendering properly on Sphinx dark mode.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

This intends to patch the xarray issue mentioned in #472
