### PR TITLE
Setup Trusted Publisher deployment to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -91,6 +91,10 @@ jobs:
     needs: build
     # Only publish from the origin repository, not forks
     if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    environment: pypi
+    permissions:
+      # This permission allows trusted publishing to PyPI (without an API token)
+      id-token: write
 
     steps:
       - name: Checkout
@@ -111,8 +115,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN}}
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
           # NOT TO BE USED in PyPI!
@@ -122,6 +124,3 @@ jobs:
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN}}


### PR DESCRIPTION
Use this instead of the API tokens we used before. It's safer and easier to use because it doesn't required generating tokens and pasting them to GitHub.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Part of https://github.com/fatiando/community/issues/141