### PR TITLE
Change default for window size in EquivalentSourcesGB

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,5 +12,4 @@ order by last name) and are considered "The Harmonica Developers":
 * [Santiago Soler](https://github.com/santisoler) - Department of Earth, Ocean and Atmospheric Sciences, University of British Columbia (ORCID: 0000-0001-9202-5317)
 * [Matthew Tankersley](https://github.com/mdtanker) - Antarctic Research Centre, Victoria University of Wellington, New Zealand (ORCID: 0000-0003-4266-8554)
 * [Leonardo Uieda](https://github.com/leouieda) - Universidade de São Paulo, Brazil (ORCID: 0000-0001-6123-9515)
-* [India Uppal](https://github.com/indiauppal) - The University of Liverpool, UK (ORCID:0000-0003-3531-2656)
 * [ziebam](https://github.com/ziebam) (not included in Zenodo)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,4 +12,5 @@ order by last name) and are considered "The Harmonica Developers":
 * [Santiago Soler](https://github.com/santisoler) - Department of Earth, Ocean and Atmospheric Sciences, University of British Columbia (ORCID: 0000-0001-9202-5317)
 * [Matthew Tankersley](https://github.com/mdtanker) - Antarctic Research Centre, Victoria University of Wellington, New Zealand (ORCID: 0000-0003-4266-8554)
 * [Leonardo Uieda](https://github.com/leouieda) - Universidade de São Paulo, Brazil (ORCID: 0000-0001-6123-9515)
+* [India Uppal](https://github.com/indiauppal) - The University of Liverpool, UK (ORCID:0000-0003-3531-2656)
 * [ziebam](https://github.com/ziebam) (not included in Zenodo)

--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -62,7 +62,7 @@ class EquivalentSourcesGB(EquivalentSources):
         If None, no block-averaging is applied.
         This parameter is ignored if *points* are specified.
         Default to None.
-    window_size : float
+    window_size : float or "default"
         Size of overlapping windows used during the gradient-boosting
         algorithm. Smaller windows reduce the memory requirements of the source
         coefficients fitting process. Very small windows may impact on the
@@ -87,6 +87,11 @@ class EquivalentSourcesGB(EquivalentSources):
         The boundaries (``[W, E, S, N]``) of the data used to fit the
         interpolator. Used as the default region for the
         :meth:`~harmonica.EquivalentSources.grid` method.
+    window_size_ : float or None
+        Size of the overlapping windows used in gradient-boosting equivalent 
+        point sources. It will be set to None if ``window_size = "default"`` 
+        and less than 5000 data points were used to fit the sources; a single
+        window will be used in such case.
 
     References
     ----------

--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -88,8 +88,8 @@ class EquivalentSourcesGB(EquivalentSources):
         interpolator. Used as the default region for the
         :meth:`~harmonica.EquivalentSources.grid` method.
     window_size_ : float or None
-        Size of the overlapping windows used in gradient-boosting equivalent 
-        point sources. It will be set to None if ``window_size = "default"`` 
+        Size of the overlapping windows used in gradient-boosting equivalent
+        point sources. It will be set to None if ``window_size = "default"``
         and less than 5000 data points were used to fit the sources; a single
         window will be used in such case.
 

--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -107,6 +107,11 @@ class EquivalentSourcesGB(EquivalentSources):
         random_state=None,
         dtype="float64",
     ):
+        if isinstance(window_size, str) and window_size != "default":
+            raise ValueError(
+                f"Found invalid 'window_size' value equal to '{window_size}'."
+                "It should be 'default' or a numeric value."
+            )
         super().__init__(
             damping=damping,
             points=points,

--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -7,6 +7,8 @@
 """
 Gradient-boosted equivalent sources in Cartesian coordinates
 """
+import warnings
+
 import numpy as np
 import verde.base as vdb
 from sklearn import utils
@@ -14,7 +16,6 @@ from verde import get_region, rolling_window
 
 from .cartesian import EquivalentSources
 from .utils import cast_fit_input, predict_numba_parallel
-import warnings
 
 
 class EquivalentSourcesGB(EquivalentSources):
@@ -291,9 +292,9 @@ class EquivalentSourcesGB(EquivalentSources):
             the same as the one in ``data_windows_nonempty``.
         data_windows_nonempty : list
             List containing arrays with the indices of the data points that
-            fall under each window. The order of the windows is randomly shuffled if
-            ``shuffle_windows`` is True, although the order of the windows is
-            the same as the one in ``source_windows_nonempty``.
+            fall under each window. The order of the windows is randomly
+            shuffled if ``shuffle_windows`` is True, although the order of the
+            windows is the same as the one in ``source_windows_nonempty``.
         """
 
         # Get the region that contains every data point and every source
@@ -304,7 +305,9 @@ class EquivalentSourcesGB(EquivalentSources):
             area = (region[1] - region[0]) * (region[3] - region[2])
             ndata = coordinates[0].size
             if ndata <= 5e3:
-                warnings.warn(f"Found {ndata} number of coordinates (<= 5e3). Only one window will be used.")
+                warnings.warn(
+                    f"Found {ndata} number of coordinates (<= 5e3). Only one window will be used."
+                )
                 source_windows_nonempty = [np.arange(self.points_[0].size)]
                 data_windows_nonempty = [np.arange(ndata)]
                 self.window_size_ = None

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -373,3 +373,26 @@ def test_error_ignored_args(coordinates_small, data_small, region):
     msg = "The 'bla' arguments are being ignored."
     with pytest.warns(FutureWarning, match=msg):
         eqs.grid(coordinates=grid_coords, bla="bla")
+
+
+def test_window_size_less_than_5000():
+    region = (0, 10e3, -5e3, 5e3)
+    grid_coords = vd.grid_coordinates(region=region, shape=(64, 64), extra_coords=0)
+    eqs = EquivalentSourcesGB()
+    eqs.points_ = eqs._build_points(
+        grid_coords
+    )  # need to build sources first before creating windows.
+    eqs._create_windows(grid_coords)
+    expected_window_size = np.sqrt(5e3 / (64**2 / 10e3**2))
+    npt.assert_allclose(eqs.window_size_, expected_window_size)
+
+def test_window_size():
+    region = (0, 10e3, -5e3, 5e3)
+    grid_coords = vd.grid_coordinates(region=region, shape=(100, 100), extra_coords=0)
+    eqs = EquivalentSourcesGB()
+    eqs.points_ = eqs._build_points(
+        grid_coords
+    )  # need to build sources first before creating windows.
+    eqs._create_windows(grid_coords)
+    expected_window_size = np.sqrt(5e3 / (100**2 / 10e3**2))
+    npt.assert_allclose(eqs.window_size_, expected_window_size)

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -386,6 +386,7 @@ def test_window_size_less_than_5000():
         eqs._create_windows(grid_coords)
     assert eqs.window_size_ is None
 
+
 def test_window_size():
     region = (0, 10e3, -5e3, 5e3)
     grid_coords = vd.grid_coordinates(region=region, shape=(100, 100), extra_coords=0)

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -405,3 +405,8 @@ def test_window_size():
     eqs._create_windows(grid_coords)
     expected_window_size = np.sqrt(5e3 / (100**2 / 10e3**2))
     npt.assert_allclose(eqs.window_size_, expected_window_size)
+
+
+def test_invalid_window_size():
+    with pytest.raises(ValueError, match=f"Found invalid 'window_size' value equal to"):
+        EquivalentSourcesGB(window_size="Chuckie took my soul!")

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -408,5 +408,5 @@ def test_window_size():
 
 
 def test_invalid_window_size():
-    with pytest.raises(ValueError, match=f"Found invalid 'window_size' value equal to"):
+    with pytest.raises(ValueError, match="Found invalid 'window_size' value equal to"):
         EquivalentSourcesGB(window_size="Chuckie took my soul!")

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -382,9 +382,9 @@ def test_window_size_less_than_5000():
     eqs.points_ = eqs._build_points(
         grid_coords
     )  # need to build sources first before creating windows.
-    eqs._create_windows(grid_coords)
-    expected_window_size = np.sqrt(5e3 / (64**2 / 10e3**2))
-    npt.assert_allclose(eqs.window_size_, expected_window_size)
+    with pytest.warns(UserWarning, match=f"Found {64**2} number of coordinates"):
+        eqs._create_windows(grid_coords)
+    assert eqs.window_size_ is None
 
 def test_window_size():
     region = (0, 10e3, -5e3, 5e3)


### PR DESCRIPTION
Change the default value for the `window_size` in the `EquivalentSourcesGB` constructor to `"default"`: window size will be estimated to locate approximately 5000 data points in each window. If `window_size="default"` and less than 5000 data points are used to fit the sources, a single window for all data and sources will be used. Check if the passed value of `window_size` is valid. Add a new `window_size_` attribute to the class that is set after fitting the sources. Update docstrings and extend tests.

**Relevant issues/PRs:**
Fixes #425 