### PR TITLE
Remove redundant urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,10 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://www.fatiando.org/harmonica"
 "Documentation" = "https://www.fatiando.org/harmonica"
-"Repository" = "https://github.com/fatiando/harmonica.git"
 "Changelog" = "https://www.fatiando.org/harmonica/latest/changes.html"
 "Bug Tracker" = "https://github.com/fatiando/harmonica/issues"
 "Source Code" = "https://github.com/fatiando/harmonica"
-"Release Notes" = "https://github.com/fatiando/harmonica/releases"
 
 [project.optional-dependencies]
 visualizations = ["pyvista>=0.27", "vtk>=9"]


### PR DESCRIPTION

Reduce the number of urls in `pyproject.toml` by removing the ones that were redundant. Keep only links to `Documentation`, `Changelog`, `Bug Tracker`, and `Source Code`.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**


Related to https://github.com/fatiando/choclo/pull/77

<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
