### PR TITLE
Fix multiple typos on `DatasetAccessorPrismLayer`

### DIFF
--- a/doc/user_guide/forward_modelling/prism.rst
+++ b/doc/user_guide/forward_modelling/prism.rst
@@ -343,10 +343,10 @@ bottom boundaries.
 It returns a :class:`xarray.Dataset` with the coordinates of the centers of the
 prisms and their corresponding physical properties.
 
-The :class:`harmonica.DatasetAccessorPrismsLayer` Dataset accessor can be used
+The :class:`harmonica.DatasetAccessorPrismLayer` Dataset accessor can be used
 to obtain some properties of the layer like its shape and size or the
 boundaries of any prism in the layer.
-Moreover, we can use the :meth:`harmonica.DatasetAcessorPrismsLayer.gravity`
+Moreover, we can use the :meth:`harmonica.DatasetAcessorPrismLayer.gravity`
 method to compute the gravitational field of the prism layer on any set of
 computation points.
 

--- a/examples/forward/prism_layer.py
+++ b/examples/forward/prism_layer.py
@@ -15,7 +15,7 @@ to create a layer of prisms: a regular grid of prisms of equal size on the
 horizontal directions with variable top and bottom boundaries. It returns
 a :class:`xarray.Dataset` with the coordinates of the centers of the prisms and
 their corresponding physical properties.
-The :class:`harmonica.DatasetAccessorPrismsLayer` Dataset accessor can be used
+The :class:`harmonica.DatasetAccessorPrismLayer` Dataset accessor can be used
 to obtain some properties of the layer like its shape and size or the
 boundaries of any prism in the layer. The methods of this Dataset accessor can
 be used together with the :func:`harmonica.prism_gravity` to compute the

--- a/harmonica/tests/test_prism_layer.py
+++ b/harmonica/tests/test_prism_layer.py
@@ -170,7 +170,7 @@ def test_prism_layer_no_regular_grid(
 
 def test_prism_layer_attributes():
     """
-    Check attributes of the DatasetAccessorPrismsLayer class
+    Check attributes of the DatasetAccessorPrismLayer class
     """
     easting = np.linspace(1, 3, 5)
     northing = np.linspace(7, 10, 4)


### PR DESCRIPTION
Fix typos when mentioning the `DatasetAccessorPrismLayer` class in docstrings and tests.
