### PR TITLE
Replace `color` for `fill` in examples using PyGMT

### DIFF
--- a/doc/user_guide/equivalent_sources/block-averaged-eqs.rst
+++ b/doc/user_guide/equivalent_sources/block-averaged-eqs.rst
@@ -106,7 +106,7 @@ And project the geographic coordinates to plain Cartesian ones:
             frame=[f"WSne+t{title}", "xa10000", "ya10000"],
             x=easting,
             y=northing,
-            color=data.total_field_anomaly_nt,
+            fill=data.total_field_anomaly_nt,
             style="c0.1c",
             cmap=True,
         )
@@ -193,7 +193,7 @@ we are efectivelly upward continuing the data.
             frame=[f"WSne+t{title}", "xa10000", "ya10000"],
             x=easting,
             y=northing,
-            color=data.total_field_anomaly_nt,
+            fill=data.total_field_anomaly_nt,
             style="c0.1c",
             cmap=True,
         )

--- a/doc/user_guide/equivalent_sources/eq-sources-spherical.rst
+++ b/doc/user_guide/equivalent_sources/eq-sources-spherical.rst
@@ -176,7 +176,7 @@ Lets plot it:
         frame=[f"WSne+t{title}", "xa5", "ya4"],
         x=longitude,
         y=latitude,
-        color=gravity_disturbance,
+        fill=gravity_disturbance,
         style="c0.1c",
         cmap=True,
     )

--- a/doc/user_guide/equivalent_sources/gradient-boosted-eqs.rst
+++ b/doc/user_guide/equivalent_sources/gradient-boosted-eqs.rst
@@ -183,7 +183,7 @@ And plot it:
             frame=[f"WSne+t{title}", "xa500000+a15", "ya400000"],
             x=easting,
             y=northing,
-            color=disturbance,
+            fill=disturbance,
             style="c0.1c",
             cmap=True,
         )

--- a/doc/user_guide/equivalent_sources/index.rst
+++ b/doc/user_guide/equivalent_sources/index.rst
@@ -139,7 +139,7 @@ And plot it:
       fig.plot(
          x=easting,
          y=northing,
-         color=disturbance,
+         fill=disturbance,
          cmap=True,
          style="c3p",
          projection=fig_proj,
@@ -155,7 +155,7 @@ And plot it:
       fig.plot(
          x=easting,
          y=northing,
-         color=data.gravity_disturbance_mgal,
+         fill=data.gravity_disturbance_mgal,
          cmap=True,
          style="c3p",
          frame=['ag', f"+t{title}"],

--- a/doc/user_guide/topographic_correction.rst
+++ b/doc/user_guide/topographic_correction.rst
@@ -76,7 +76,7 @@ And plot it:
    fig.plot(
       x=data.longitude,
       y=data.latitude,
-      color=data.gravity_disturbance_mgal,
+      fill=data.gravity_disturbance_mgal,
       cmap=True,
       style="c3p",
       projection="M15c",
@@ -129,7 +129,7 @@ We can now compute the Bouguer disturbance and plot it:
    fig.plot(
       x=data.longitude,
       y=data.latitude,
-      color=bouguer_disturbance,
+      fill=bouguer_disturbance,
       cmap=True,
       style="c3p",
       projection="M15c",
@@ -249,7 +249,7 @@ And plot it:
    fig.plot(
       x=data.longitude,
       y=data.latitude,
-      color=topo_free_disturbance,
+      fill=topo_free_disturbance,
       cmap=True,
       style="c3p",
       projection="M15c",

--- a/examples/equivalent_sources/block_averaged_sources.py
+++ b/examples/equivalent_sources/block_averaged_sources.py
@@ -123,7 +123,7 @@ with pygmt.config(FONT_TITLE="12p"):
         frame=[f"WSne+t{title}", "xa10000", "ya10000"],
         x=easting,
         y=northing,
-        color=data.total_field_anomaly_nt,
+        fill=data.total_field_anomaly_nt,
         style="c0.1c",
         cmap=True,
     )

--- a/examples/equivalent_sources/cartesian.py
+++ b/examples/equivalent_sources/cartesian.py
@@ -112,7 +112,7 @@ with pygmt.config(FONT_TITLE="12p"):
         frame=[f"WSne+t{title}", "xa10000", "ya10000"],
         x=easting,
         y=northing,
-        color=data.total_field_anomaly_nt,
+        fill=data.total_field_anomaly_nt,
         style="c0.1c",
         cmap=True,
     )

--- a/examples/equivalent_sources/gradient_boosted.py
+++ b/examples/equivalent_sources/gradient_boosted.py
@@ -131,7 +131,7 @@ with pygmt.config(FONT_TITLE="14p"):
         frame=[f"WSne+t{title}", "xa200000+a15", "ya100000"],
         x=easting,
         y=northing,
-        color=data.gravity_disturbance,
+        fill=data.gravity_disturbance,
         style="c0.1c",
         cmap=True,
     )

--- a/examples/equivalent_sources/spherical.py
+++ b/examples/equivalent_sources/spherical.py
@@ -96,7 +96,7 @@ fig.plot(
     frame=["WSne", "xa5", "ya4"],
     x=longitude,
     y=latitude,
-    color=gravity_disturbance,
+    fill=gravity_disturbance,
     style="c0.1c",
     cmap=True,
 )

--- a/examples/forward/point_gravity.py
+++ b/examples/forward/point_gravity.py
@@ -67,7 +67,7 @@ with pygmt.config(FONT_TITLE="16p"):
         cmap=True,
     )
 
-fig.plot(x=easting, y=northing, style="c0.2c", color="grey")
+fig.plot(x=easting, y=northing, style="c0.2c", fill="grey")
 
 fig.colorbar(cmap=True, position="JMR", frame=["a.6f.2", "x+lmGal"])
 

--- a/examples/forward/point_gravity.py
+++ b/examples/forward/point_gravity.py
@@ -67,7 +67,7 @@ with pygmt.config(FONT_TITLE="16p"):
         cmap=True,
     )
 
-fig.plot(x=easting, y=northing, style="c0.2c", fill="grey")
+fig.plot(x=easting, y=northing, style="c0.2c", color="grey")
 
 fig.colorbar(cmap=True, position="JMR", frame=["a.6f.2", "x+lmGal"])
 


### PR DESCRIPTION
The `color` argument in plot functions of PyGMT has been removed, so we need to replace it for the new `fill` argument.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

Fixes #449