### PR TITLE
Bump minimum version of Numpy to 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,9 +79,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-        run: |
-          echo "Update pip:"
-          python -m pip install --upgrade pip
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
 
       - name: Collect requirements
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+        run: |
+          echo "Update pip:"
+          python -m pip install --upgrade pip
 
       - name: Collect requirements
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >= 1.22.4",
+    "numpy >= 1.23",
     "pandas >= 1.1",
     "scipy >= 1.5",
     "scikit-learn >= 0.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >= 1.21",
+    "numpy >= 1.22",
     "pandas >= 1.1",
     "scipy >= 1.5",
     "scikit-learn >= 0.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >= 1.22",
+    "numpy >= 1.22.4",
     "pandas >= 1.1",
     "scipy >= 1.5",
     "scikit-learn >= 0.24",


### PR DESCRIPTION
Numpy dropped support for the 1.21 version on Jun 23, 2023. Running the
Harmonica tests in MacOS with Python 3.8  and Numpy v1.21 was impossible
because of installation error of Numpy using `pip`.

Lets see if with this new version the issue is resolved.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
