### PR TITLE
Run tests with oldest dependencies on x86 macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,16 @@ jobs:
   # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         dependencies:
           - oldest
           - latest
@@ -50,12 +50,12 @@ jobs:
           - dependencies: optional
             python: "3.11"
           # test on macos-13 (x86) using oldest dependencies and python 3.8
-          - dependencies: oldest
-            os: macos-13
+          - os: macos-13
+            dependencies: oldest
             python: "3.8"
         exclude:
           # don't test on macos (arm64) with oldest dependencies
-          - os: macos
+          - os: macos-latest
             dependencies: oldest
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,15 @@ jobs:
             python: "3.11"
           - dependencies: optional
             python: "3.11"
+          # test on macos-13 (x86) using oldest dependencies and python 3.8
+          - dependencies: oldest
+            os: macos-13
+            python: "3.8"
+        exclude:
+          # don't test on macos (arm64) with oldest dependencies
+          - os: macos
+            dependencies: oldest
+
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-tests.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
             dependencies: oldest
             python: "3.8"
         exclude:
-          # don't test on macos (arm64) with oldest dependencies
+          # don't test on macos-latest (arm64) with oldest dependencies
           - os: macos-latest
             dependencies: oldest
 


### PR DESCRIPTION
Change configuration of tests in GitHub Actions: use the latest x86 macos runner with the `oldest` dependencies and Python 3.8. Use the latest macos runner (arm64) only against the `latest` and `optional` requirements.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
