### PR TITLE
Run tests with oldest dependencies on x86 macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,16 @@ jobs:
   # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         dependencies:
           - oldest
           - latest
@@ -50,12 +50,12 @@ jobs:
           - dependencies: optional
             python: "3.11"
           # test on macos-13 (x86) using oldest dependencies and python 3.8
-          - dependencies: oldest
-            os: macos-13
+          - os: macos-13
+            dependencies: oldest
             python: "3.8"
         exclude:
           # don't test on macos (arm64) with oldest dependencies
-          - os: macos
+          - os: macos-latest
             dependencies: oldest
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,15 @@ jobs:
             python: "3.11"
           - dependencies: optional
             python: "3.11"
+          # test on macos-13 (x86) using oldest dependencies and python 3.8
+          - dependencies: oldest
+            os: macos-13
+            python: "3.8"
+        exclude:
+          # don't test on macos (arm64) with oldest dependencies
+          - os: macos
+            dependencies: oldest
+
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-tests.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
             dependencies: oldest
             python: "3.8"
         exclude:
-          # don't test on macos (arm64) with oldest dependencies
+          # don't test on macos-latest (arm64) with oldest dependencies
           - os: macos-latest
             dependencies: oldest
 


### PR DESCRIPTION
Change configuration of tests in GitHub Actions: use the latest x86 macos runner with the `oldest` dependencies and Python 3.8. Use the latest macos runner (arm64) only against the `latest` and `optional` requirements. This fixes CI failing because there are not Numpy binaries in PyPI for arm64 and compatible with Python 3.8.
