### PR TITLE
Fix check of runner OS in test Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Run the tests
         run: |
-          if [ ${{ matrix.os }} == 'ubuntu' ]; then
+          if [ ${{ matrix.os }} == *"ubuntu"* ]; then
               # Set NUMBA_THREADING_LAYER to workqueue on Ubuntu to prevent
               # endless loop on some test functions that make use of Numba
               NUMBA_THREADING_LAYER=workqueue make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,8 +145,10 @@ jobs:
           if [ $RUNNER_OS == "Linux" ]; then
               # Set NUMBA_THREADING_LAYER to workqueue on Ubuntu to prevent
               # endless loop on some test functions that make use of Numba
+              echo "Running `NUMBA_THREADING_LAYER=workqueue make test`"
               NUMBA_THREADING_LAYER=workqueue make test
           else
+              echo "Running `make test`"
               make test
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Run the tests
         run: |
-          if [ ${{ matrix.os }} == *"ubuntu"* ]; then
+          if [ $RUNNER_OS == "Linux" ]; then
               # Set NUMBA_THREADING_LAYER to workqueue on Ubuntu to prevent
               # endless loop on some test functions that make use of Numba
               NUMBA_THREADING_LAYER=workqueue make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,10 +145,10 @@ jobs:
           if [ $RUNNER_OS == "Linux" ]; then
               # Set NUMBA_THREADING_LAYER to workqueue on Ubuntu to prevent
               # endless loop on some test functions that make use of Numba
-              echo "Running `NUMBA_THREADING_LAYER=workqueue make test`"
+              echo "Running 'NUMBA_THREADING_LAYER=workqueue make test'"
               NUMBA_THREADING_LAYER=workqueue make test
           else
-              echo "Running `make test`"
+              echo "Running 'make test'"
               make test
           fi
 


### PR DESCRIPTION
Fix an if statement that checks if the current runner is a Ubuntu machine. Instead of comparing the `matrix.os` variable, rely on the `$RUNNER_OS` env variable provided by Actions. Add echo commands to increase verbosity.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Changes motivated by the modifications introduced in #499
