### PR TITLE
Move codecov push to its own job in Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
 
   #############################################################################
   # Upload coverage report to codecov
-  codecov:
+  codecov-upload:
     runs-on: ubuntu-latest
     needs: test
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage
-          path: ./coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.dependencies }}
+          name: coverage_${{ matrix.os }}_${{ matrix.dependencies }}
           path: ./coverage.xml
 
 
@@ -173,7 +173,7 @@ jobs:
         # the artifact.
         uses: actions/download-artifact@v4
         with:
-          pattern: coverage-*
+          pattern: coverage_*
 
       - name: List all downloaded artifacts
         run: ls -l -R .
@@ -182,7 +182,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           # Upload all coverage report files
-          files: ./coverage-*/coverage.xml
+          files: ./coverage_*/coverage.xml
           # Fail the job so we know coverage isn't being updated. Otherwise it
           # can silently drop and we won't know.
           fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,11 +163,6 @@ jobs:
   codecov-upload:
     runs-on: ubuntu-latest
     needs: test
-    env:
-      # Used to tag codecov submissions
-      OS: "ubuntu"
-      PYTHON: "3.11"
-      DEPENDENCIES: "optional"
 
     steps:
 
@@ -188,7 +183,6 @@ jobs:
         with:
           # Upload all coverage report files
           files: ./coverage-*/coverage.xml
-          env_vars: OS,PYTHON,DEPENDENCIES
           # Fail the job so we know coverage isn't being updated. Otherwise it
           # can silently drop and we won't know.
           fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,10 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage report as an artifact
-        if: success() && runner.os == 'Linux' && matrix.dependencies == 'latest'
+        # Upload a single report for the whole matrix: the one obtained in the
+        # Ubuntu runner using optional dependencies (to maximize the tests
+        # being run)
+        if: success() && runner.os == 'Linux' && matrix.dependencies == 'optional'
         uses: actions/upload-artifact@v4
         with:
           name: coverage
@@ -166,7 +169,7 @@ jobs:
       # Used to tag codecov submissions
       OS: "ubuntu"
       PYTHON: "3.11"
-      DEPENDENCIES: "latest"
+      DEPENDENCIES: "optional"
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   #############################################################################
-  # Run tests and upload to codecov
+  # Run tests
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
     runs-on: ${{ matrix.os }}
@@ -60,10 +60,6 @@ jobs:
 
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-tests.txt
-      # Used to tag codecov submissions
-      OS: ${{ matrix.os }}
-      PYTHON: ${{ matrix.python }}
-      DEPENDENCIES: ${{ matrix.dependencies }}
 
     steps:
 
@@ -152,6 +148,31 @@ jobs:
 
       - name: Convert coverage report to XML for codecov
         run: coverage xml
+
+      - name: Upload coverage report as an artifact
+        if: success() && ${{ runner.os == "Linux" }} && ${{ matrix.dependencies == "latest" }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ./coverage.xml
+
+
+  #############################################################################
+  # Upload coverage report to codecov
+  codecov:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      # Used to tag codecov submissions
+      OS: "ubuntu"
+      PYTHON: "3.11"
+      DEPENDENCIES: "latest"
+
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: ./coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,11 +162,13 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     needs: test
-    steps:
+    env:
       # Used to tag codecov submissions
       OS: "ubuntu"
       PYTHON: "3.11"
       DEPENDENCIES: "latest"
+
+    steps:
 
       - name: Download coverage report artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,8 +152,6 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage report as an artifact
-        # Upload coverage reports for the whole matrix. Coverage is achieved
-        # combining reports from every runner.
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.dependencies }}
@@ -174,17 +172,22 @@ jobs:
     steps:
 
       - name: Download coverage report artifacts
+        # Download coverage reports from every runner.
+        # Maximum coverage is achieved by combining reports from every runner.
+        # Each coverage file will live in its own folder with the same name as
+        # the artifact.
         uses: actions/download-artifact@v4
         with:
           pattern: coverage-*
-          path: coverages/
 
-      - run: ls -l .
+      - name: List all downloaded artifacts
+        run: ls -l -R .
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: ./coverages/**/coverage.xml
+          # Upload all coverage report files
+          files: ./coverage-*/coverage.xml
           env_vars: OS,PYTHON,DEPENDENCIES
           # Fail the job so we know coverage isn't being updated. Otherwise it
           # can silently drop and we won't know.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,14 +152,12 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage report as an artifact
-        # Upload a single report for the whole matrix: the one obtained in the
-        # Ubuntu runner using optional dependencies (to maximize the tests
-        # being run)
-        if: success() && runner.os == 'Linux' && matrix.dependencies == 'optional'
+        # Upload coverage reports for the whole matrix. Coverage is achieved
+        # combining reports from every runner.
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
-          path: ./coverage.xml
+          name: coverage-${{ matrix.os }}-${{ matrix.dependencies }}
+          path: ./coverage-${{ matrix.os }}-${{ matrix.dependencies }}.xml
 
 
   #############################################################################
@@ -175,15 +173,19 @@ jobs:
 
     steps:
 
-      - name: Download coverage report artifact
+      - name: Download coverage report artifacts
         uses: actions/download-artifact@v4
         with:
           name: coverage
+          pattern: coverage-*
+          merge-multiple: true
+
+      - run: ls -l .
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          files: ./coverage-*.xml
           env_vars: OS,PYTHON,DEPENDENCIES
           # Fail the job so we know coverage isn't being updated. Otherwise it
           # can silently drop and we won't know.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ on:
 
 # Define variables used by all jobs
 env:
-  PYTHON_OLDEST = "3.8"
-  PYTHON_LATEST = "3.11"
+  PYTHON_OLDEST: "3.8"
+  PYTHON_LATEST: "3.11"
 
 # Use bash by default in all jobs
 defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage report as an artifact
-        if: success() && ${{ runner.os == "Linux" }} && ${{ matrix.dependencies == "latest" }}
+        if: success() && runner.os == "Linux" && ${{ matrix.dependencies == "latest" }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage report as an artifact
-        if: success() && runner.os == "Linux" && ${{ matrix.dependencies == "latest" }}
+        if: success() && runner.os == "Linux" && matrix.dependencies == "latest"
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,13 +149,7 @@ jobs:
           fi
 
       - name: Convert coverage report to XML for codecov
-        run: |
-          coverage xml
-          # Rename coverage file to upload it as artifact
-          mv coverage.xml coverage-$OS-$DEPENDENCIES.xml
-        env:
-          OS: ${{ matrix.os }}
-          DEPENDENCIES: ${{ matrix.dependencies }}
+        run: coverage xml
 
       - name: Upload coverage report as an artifact
         # Upload coverage reports for the whole matrix. Coverage is achieved
@@ -163,7 +157,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.dependencies }}
-          path: ./coverage-${{ matrix.os }}-${{ matrix.dependencies }}.xml
+          path: ./coverage.xml
 
 
   #############################################################################
@@ -182,16 +176,15 @@ jobs:
       - name: Download coverage report artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage
           pattern: coverage-*
-          merge-multiple: true
+          path: coverages/
 
       - run: ls -l .
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: ./coverage-*.xml
+          files: ./coverages/**/coverage.xml
           env_vars: OS,PYTHON,DEPENDENCIES
           # Fail the job so we know coverage isn't being updated. Otherwise it
           # can silently drop and we won't know.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,13 @@ jobs:
           fi
 
       - name: Convert coverage report to XML for codecov
-        run: coverage xml
+        run: |
+          coverage xml
+          # Rename coverage file to upload it as artifact
+          mv coverage.xml coverage-$OS-$DEPENDENCIES.xml
+        env:
+          OS: ${{ matrix.os }}
+          DEPENDENCIES: ${{ matrix.dependencies }}
 
       - name: Upload coverage report as an artifact
         # Upload coverage reports for the whole matrix. Coverage is achieved

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,12 @@ on:
     types:
       - published
 
+
+# Define variables used by all jobs
+env:
+  PYTHON_OLDEST = "3.8"
+  PYTHON_LATEST = "3.11"
+
 # Use bash by default in all jobs
 defaults:
   run:
@@ -44,15 +50,15 @@ jobs:
           - optional
         include:
           - dependencies: oldest
-            python: "3.8"
+            python: ${{ env.PYTHON_OLDEST }}
           - dependencies: latest
-            python: "3.11"
+            python: ${{ env.PYTHON_LATEST }}
           - dependencies: optional
-            python: "3.11"
+            python: ${{ env.PYTHON_LATEST }}
           # test on macos-13 (x86) using oldest dependencies and python 3.8
           - os: macos-13
             dependencies: oldest
-            python: "3.8"
+            python: ${{ env.PYTHON_OLDEST }}
         exclude:
           # don't test on macos-latest (arm64) with oldest dependencies
           - os: macos-latest
@@ -170,7 +176,7 @@ jobs:
     env:
       # Used to tag codecov submissions
       OS: "ubuntu"
-      PYTHON: "3.11"
+      PYTHON: ${{ env.PYTHON_LATEST }}
       DEPENDENCIES: "optional"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ on:
 
 # Define variables used by all jobs
 env:
-  PYTHON_OLDEST: "3.8"
-  PYTHON_LATEST: "3.11"
+  PYTHON_OLDEST = "3.8"
+  PYTHON_LATEST = "3.11"
 
 # Use bash by default in all jobs
 defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,6 @@ on:
     types:
       - published
 
-
-# Define variables used by all jobs
-env:
-  PYTHON_OLDEST = "3.8"
-  PYTHON_LATEST = "3.11"
-
 # Use bash by default in all jobs
 defaults:
   run:
@@ -50,15 +44,15 @@ jobs:
           - optional
         include:
           - dependencies: oldest
-            python: ${{ env.PYTHON_OLDEST }}
+            python: "3.8"
           - dependencies: latest
-            python: ${{ env.PYTHON_LATEST }}
+            python: "3.11"
           - dependencies: optional
-            python: ${{ env.PYTHON_LATEST }}
+            python: "3.11"
           # test on macos-13 (x86) using oldest dependencies and python 3.8
           - os: macos-13
             dependencies: oldest
-            python: ${{ env.PYTHON_OLDEST }}
+            python: "3.8"
         exclude:
           # don't test on macos-latest (arm64) with oldest dependencies
           - os: macos-latest
@@ -176,7 +170,7 @@ jobs:
     env:
       # Used to tag codecov submissions
       OS: "ubuntu"
-      PYTHON: ${{ env.PYTHON_LATEST }}
+      PYTHON: "3.11"
       DEPENDENCIES: "optional"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage report as an artifact
-        if: success() && runner.os == "Linux" && matrix.dependencies == "latest"
+        if: success() && runner.os == 'Linux' && matrix.dependencies == 'latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,4 +12,5 @@ order by last name) and are considered "The Harmonica Developers":
 * [Santiago Soler](https://github.com/santisoler) - Department of Earth, Ocean and Atmospheric Sciences, University of British Columbia (ORCID: 0000-0001-9202-5317)
 * [Matthew Tankersley](https://github.com/mdtanker) - Antarctic Research Centre, Victoria University of Wellington, New Zealand (ORCID: 0000-0003-4266-8554)
 * [Leonardo Uieda](https://github.com/leouieda) - Universidade de São Paulo, Brazil (ORCID: 0000-0001-6123-9515)
+* [India Uppal](https://github.com/indiauppal) - The University of Liverpool, UK (ORCID: 0000-0003-3531-2656)
 * [ziebam](https://github.com/ziebam) (not included in Zenodo)


### PR DESCRIPTION
Remove the push to codecov step from the `test` job into a new job that depends on the test job. Upload the coverage reports as artifacts after testing, and reuse the artifacts in the new job. Upload all coverage reports in a single push to Codecov to minimize the number of hits.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to fatiando/community#151
