### PR TITLE
Add _version.py to .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,5 @@
 branch = True
 omit =
     */tests/*
-    */_version_generated.py
+    */_version.py
     **/__init__.py


### PR DESCRIPTION
Replace the old `_version_generated.py` for the new `_version`.py in the configuration of `coverage`.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
