### PR TITLE
fix bug #439 with reduction_to_pole filter error

### DIFF
--- a/harmonica/filters/_filters.py
+++ b/harmonica/filters/_filters.py
@@ -472,7 +472,7 @@ def reduction_to_pole_kernel(
         magnetization_declination,
     )
     # Set 0 wavenumber to 0
-    da_filter.loc[dict(freq_northing=0, freq_easting=0)] = 0
+    da_filter.loc[{dims[0] : 0, dims[1] : 0}] = 0
     return da_filter
 
 


### PR DESCRIPTION
<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #439 bug issue:  the reduction_to_pole filter produces an error when grid coordinate names are not "northing" and "easting". <br>
Now, it works regardless of grid coordinate names.
