### PR TITLE
Extend support for Numpy 2.0

### DIFF
--- a/harmonica/_equivalent_sources/cartesian.py
+++ b/harmonica/_equivalent_sources/cartesian.py
@@ -222,7 +222,9 @@ class EquivalentSources(vdb.BaseGridder):
         self.region_ = vd.get_region(coordinates[:2])
         coordinates = vdb.n_1d_arrays(coordinates, 3)
         if self.points is None:
-            self.points_ = self._build_points(coordinates)
+            self.points_ = tuple(
+                p.astype(self.dtype) for p in self._build_points(coordinates)
+            )
         else:
             self.depth_ = None  # set depth_ to None so we don't leave it unset
             self.points_ = tuple(

--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -142,7 +142,7 @@ class EquivalentSourcesGB(EquivalentSources):
 
         Returns
         -------
-        memory_required : float
+        memory_required : int
             Amount of memory required to store the largest Jacobian matrix in
             bytes.
 
@@ -157,7 +157,8 @@ class EquivalentSourcesGB(EquivalentSources):
         ...     random_state=42,
         ... )
         >>> eqs = EquivalentSourcesGB(window_size=2e3)
-        >>> eqs.estimate_required_memory(coordinates)
+        >>> n_bytes = eqs.estimate_required_memory(coordinates)
+        >>> int(n_bytes)
         9800
         """
         # Build the sources and assign the points_ attribute

--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -216,7 +216,9 @@ class EquivalentSourcesGB(EquivalentSources):
             weights = weights.ravel()
         # Build point sources
         if self.points is None:
-            self.points_ = self._build_points(coordinates)
+            self.points_ = tuple(
+                p.astype(self.dtype) for p in self._build_points(coordinates)
+            )
         else:
             self.points_ = tuple(
                 p.astype(self.dtype) for p in vdb.n_1d_arrays(self.points, 3)

--- a/harmonica/_forward/prism_layer.py
+++ b/harmonica/_forward/prism_layer.py
@@ -107,11 +107,13 @@ def prism_layer(
         coords_units:      meters
         properties_units:  SI
     >>> # Get the boundaries of the layer (will exceed the region)
-    >>> print(prisms.prism_layer.boundaries)
-    (-1.25, 11.25, 1.0, 9.0)
+    >>> boundaries = prisms.prism_layer.boundaries
+    >>> list(float(b) for b in boundaries)
+    [-1.25, 11.25, 1.0, 9.0]
     >>> # Get the boundaries of one of the prisms
-    >>> print(prisms.prism_layer.get_prism((0, 2)))
-    (3.75, 6.25, 1.0, 3.0, 0.0, 2.0)
+    >>> prism = prisms.prism_layer.get_prism((0, 2))
+    >>> list(float(b) for b in prism)
+    [3.75, 6.25, 1.0, 3.0, 0.0, 2.0]
     """  # noqa: W505
     dims = ("northing", "easting")
     # Initialize data and data_names as None


### PR DESCRIPTION
Convert Numpy scalars to Python numbers so the outputs of examples that are being compared when running doctests support Numpy>=2.0. Cast `points` in equivalent source classes to the desired `dtype` passed as argument.
