### PR TITLE
Add Homepage to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 ]
 
 [project.urls]
+"Homepage" = "https://www.fatiando.org/harmonica"
 "Documentation" = "https://www.fatiando.org/harmonica"
 "Changelog" = "https://www.fatiando.org/harmonica/latest/changes.html"
 "Bug Tracker" = "https://github.com/fatiando/harmonica/issues"


### PR DESCRIPTION
Fix issue with `twine` failing to check the built package due to missing `"home-page"` key in the metadata.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
