### PR TITLE
Raise error for zero depth value in equivalent sources

### DIFF
--- a/harmonica/_equivalent_sources/cartesian.py
+++ b/harmonica/_equivalent_sources/cartesian.py
@@ -110,7 +110,7 @@ class EquivalentSources(vdb.BaseGridder):
     depth : float or "default"
         Parameter used to control the depth at which the point sources will be
         located.
-        If a value is provided, each source is located beneath each data point
+        If a non-zero value is provided, each source is located beneath each data point
         (or block-averaged location) at a depth equal to its elevation minus
         the ``depth`` value.
         If set to ``"default"``, the depth of the sources will be estimated as
@@ -178,6 +178,11 @@ class EquivalentSources(vdb.BaseGridder):
                 f"Found invalid 'depth' value equal to '{depth}'. "
                 "It should be 'default' or a numeric value."
             )
+        if depth == 0:
+            raise ValueError(
+                "Depth value cannot be zero. It should be a non-zero numeric value."
+            )
+
         self.damping = damping
         self.points = points
         self.depth = depth

--- a/harmonica/_equivalent_sources/cartesian.py
+++ b/harmonica/_equivalent_sources/cartesian.py
@@ -110,9 +110,9 @@ class EquivalentSources(vdb.BaseGridder):
     depth : float or "default"
         Parameter used to control the depth at which the point sources will be
         located.
-        If a non-zero value is provided, each source is located beneath each data point
-        (or block-averaged location) at a depth equal to its elevation minus
-        the ``depth`` value.
+        If a non-zero value is provided, each source is located beneath each
+        data point (or block-averaged location) at a depth equal to its
+        elevation minus the ``depth`` value.
         If set to ``"default"``, the depth of the sources will be estimated as
         4.5 times the mean distance between first neighboring sources.
         This parameter is ignored if *points* is specified.

--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -450,3 +450,13 @@ def test_invalid_depth():
     msg = f"Found invalid 'depth' value equal to '{invalid_depth}'"
     with pytest.raises(ValueError, match=msg):
         EquivalentSources(depth=invalid_depth)
+
+
+def test_zero_depth():
+    """
+    Test if error is raised after passing zero for depth.
+    """
+    zero_depth = 0
+    msg = "Depth value cannot be zero. It should be a non-zero numeric value."
+    with pytest.raises(ValueError, match=msg):
+        EquivalentSources(depth=zero_depth)

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -434,3 +434,13 @@ def test_invalid_depth():
     msg = f"Found invalid 'depth' value equal to '{invalid_depth}'"
     with pytest.raises(ValueError, match=msg):
         EquivalentSourcesGB(depth=invalid_depth)
+
+
+def test_zero_depth():
+    """
+    Test if error is raised after passing zero for depth.
+    """
+    zero_depth = 0
+    msg = "Depth value cannot be zero. It should be a non-zero numeric value."
+    with pytest.raises(ValueError, match=msg):
+        EquivalentSourcesGB(depth=zero_depth)


### PR DESCRIPTION
Raise error message for zero depth values in EquivalentSources and EquivalentSourcesGB classes.
Add associated tests.

Fix #523 