### PR TITLE
Replace `build` for `python-build` in environment.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "Rename conda-forge packages in requirements-full.txt"
           # Replace "build" for "python-build"
-          sed -s --in-place 's/^build$/python-build' requirements-full.txt
+          sed -s --in-place 's/^build$/python-build/' requirements-full.txt
           echo "Renamed dependencies:"
           cat requirements-full.txt
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,12 @@ jobs:
           echo "Collected dependencies:"
           cat requirements-full.txt
 
+      - name: Rename conda-forge packages
+        run: |
+          echo "Rename conda-forge packages in requirements-full.txt"
+          # Replace "build" for "python-build"
+          sed -s 's/^build$/python-build'
+
       - name: Setup caching for conda packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,7 +88,9 @@ jobs:
         run: |
           echo "Rename conda-forge packages in requirements-full.txt"
           # Replace "build" for "python-build"
-          sed -s 's/^build$/python-build'
+          sed -s --in-place 's/^build$/python-build' requirements-full.txt
+          echo "Renamed dependencies:"
+          cat requirements-full.txt
 
       - name: Setup caching for conda packages
         uses: actions/cache@v4

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python==3.12.*
   - pip
   # Build
-  - build
+  - python-build
   - twine
   # Run-time
   - numpy


### PR DESCRIPTION
The `build` package in `conda-forge` is outdated, `python-build` should be used instead.
