### PR TITLE
Remove links from whitespaces between README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,36 +14,11 @@ Part of the <a href="https://www.fatiando.org"><strong>Fatiando a Terra</strong>
 </p>
 
 <p align="center">
-<a href="https://pypi.python.org/pypi/harmonica">
-<img
-src="http://img.shields.io/pypi/v/harmonica.svg?style=flat-square"
-alt="Latest version on PyPI"
-/>
-</a>
-<a href="https://github.com/conda-forge/harmonica-feedstock">
-<img
-src="https://img.shields.io/conda/vn/conda-forge/harmonica.svg?style=flat-square"
-alt="Latest version on conda-forge"
-/>
-</a>
-<a href="https://codecov.io/gh/fatiando/harmonica">
-<img
-src="https://img.shields.io/codecov/c/github/fatiando/harmonica/main.svg?style=flat-square"
-alt="Test coverage status"
-/>
-</a>
-<a href="https://pypi.python.org/pypi/harmonica">
-<img
-src="https://img.shields.io/pypi/pyversions/harmonica.svg?style=flat-square"
-alt="Compatible Python versions."
-/>
-</a>
-<a href="https://doi.org/10.5281/zenodo.3628741">
-<img
-src="https://img.shields.io/badge/doi-10.5281%2Fzenodo.3628741-blue.svg?style=flat-square"
-alt="Digital Object Identifier for the Zenodo archive"
-/>
-</a>
+<a href="https://pypi.python.org/pypi/harmonica"><img src="http://img.shields.io/pypi/v/harmonica.svg?style=flat-square" alt="Latest version on PyPI"/></a>
+<a href="https://github.com/conda-forge/harmonica-feedstock"><img src="https://img.shields.io/conda/vn/conda-forge/harmonica.svg?style=flat-square" alt="Latest version on conda-forge"/></a>
+<a href="https://codecov.io/gh/fatiando/harmonica"><img src="https://img.shields.io/codecov/c/github/fatiando/harmonica/main.svg?style=flat-square" alt="Test coverage status"/></a>
+<a href="https://pypi.python.org/pypi/harmonica"><img src="https://img.shields.io/pypi/pyversions/harmonica.svg?style=flat-square" alt="Compatible Python versions."/></a>
+<a href="https://doi.org/10.5281/zenodo.3628741"><img src="https://img.shields.io/badge/doi-10.5281%2Fzenodo.3628741-blue.svg?style=flat-square" alt="Digital Object Identifier for the Zenodo archive"/></a>
 </p>
 
 # About


### PR DESCRIPTION
The badges in the README had hyperlinks in the whitespace between them because of the line breaks in the `<a>` tags. Make them all a single line to remove the links.
