### PR TITLE
Remove mention of not doing horizontal derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Things that will *not* be covered in Harmonica:
 - Multi-physics partial differential equation solvers. Use
   [SimPEG](http://www.simpeg.xyz/) or [PyGIMLi](https://www.pygimli.org/)
   instead.
-- Generic grid processing methods (like horizontal derivatives and FFT). We'll
-  rely on [Verde](https://www.fatiando.org/verde),
+- Generic grid processing methods (like FFT and standards interpolation).
+  We'll rely on [Verde](https://www.fatiando.org/verde),
   [xrft](https://xrft.readthedocs.io/en/latest/) and
   [xarray](https://xarray.dev) for those.
 - Data visualization.


### PR DESCRIPTION
We mentioned in the README that horizontal derivatives would go into Verde but we ended up coding them here. So remove that from the README and include normal interpolation instead,

