### PR TITLE
Fix equivalent sources tests failing after sklearn 1.6.0

### DIFF
--- a/harmonica/tests/test_eq_sources_cartesian.py
+++ b/harmonica/tests/test_eq_sources_cartesian.py
@@ -108,6 +108,8 @@ def fixture_coordinates_9x9(region):
     ("damping", "dtype"),
     [
         (None, "default"),
+        (1e-12, "default"),
+        (1e-12, np.float32),
         pytest.param(
             None,
             np.float32,
@@ -118,8 +120,6 @@ def fixture_coordinates_9x9(region):
                 )
             ),
         ),
-        (1e-12, "default"),
-        (1e-12, np.float32),
     ],
 )
 def test_equivalent_sources_cartesian(

--- a/harmonica/tests/test_eq_sources_spherical.py
+++ b/harmonica/tests/test_eq_sources_spherical.py
@@ -90,7 +90,7 @@ def test_equivalent_sources_spherical():
     # The interpolation should be perfect on the data points
     eqs = EquivalentSourcesSph(relative_depth=500e3)
     eqs.fit(coordinates, data)
-    npt.assert_allclose(data, eqs.predict(coordinates), rtol=1.3e-5)
+    npt.assert_allclose(data, eqs.predict(coordinates), rtol=1.3e-5, atol=1e-11)
 
     # Gridding onto a denser grid should be reasonably accurate when compared
     # to synthetic values
@@ -100,7 +100,7 @@ def test_equivalent_sources_spherical():
     true = point_gravity(
         grid_coords, points, masses, field="g_z", coordinate_system="spherical"
     )
-    npt.assert_allclose(true, eqs.predict(grid_coords), rtol=1e-3)
+    npt.assert_allclose(true, eqs.predict(grid_coords), rtol=1e-3, atol=1e-11)
 
     # Test grid method
     grid = eqs.grid(grid_coords)

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -178,7 +178,7 @@ def test_gradient_boosted_eqs_single_window(region, points, masses, coordinates,
     # to synthetic values
     grid = vd.grid_coordinates(region, shape=(60, 60), extra_coords=0)
     true = point_gravity(grid, points, masses, field="g_z")
-    npt.assert_allclose(true, eqs.predict(grid), rtol=1e-3)
+    npt.assert_allclose(true, eqs.predict(grid), rtol=1e-3, atol=5e-8)
 
 
 @run_only_with_numba

--- a/harmonica/tests/test_gradient_boosted_eqs.py
+++ b/harmonica/tests/test_gradient_boosted_eqs.py
@@ -171,14 +171,15 @@ def test_gradient_boosted_eqs_single_window(region, points, masses, coordinates,
     """
     Test GB eq-sources with a single window that covers the whole region
     """
+    atol = 5e-8
     eqs = EquivalentSourcesGB(depth=500, window_size=region[1] - region[0])
     eqs.fit(coordinates, data)
-    npt.assert_allclose(data, eqs.predict(coordinates), rtol=1e-5)
+    npt.assert_allclose(data, eqs.predict(coordinates), rtol=1e-5, atol=atol)
     # Gridding onto a denser grid should be reasonably accurate when compared
     # to synthetic values
     grid = vd.grid_coordinates(region, shape=(60, 60), extra_coords=0)
     true = point_gravity(grid, points, masses, field="g_z")
-    npt.assert_allclose(true, eqs.predict(grid), rtol=1e-3, atol=5e-8)
+    npt.assert_allclose(true, eqs.predict(grid), rtol=1e-3, atol=atol)
 
 
 @run_only_with_numba


### PR DESCRIPTION
Test cartesian equivalent sources with f32 and f64 dtypes and also with `damping` as `None` and with a very small value. Mark the combination of `damping=None` and `dtype=np.float32` with `xfail`, so it gets flagged but `pytest` doesn't error out. Since the equivalent sources with damping are more accurate, we don't need to have different absolute tolerances for both cases: keep a single value for `atol`. Set some very low absolute tolerances in spherical equivalent sources tests and in gradient-boosted equivalent sources tests.

**Relevant issues/PRs:**

Fixes #546
