### PR TITLE
Fetch Ensaio data from GitHub in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-docs.txt
       PYTHON: "3.12"
+      ENSAIO_DATA_FROM_GITHUB: true
 
     steps:
 


### PR DESCRIPTION
Set the `ENSAIO_DATA_FROM_GITHUB=true` environment variable in the docs build so data are fetched from GitHub instead of Zenodo. Helps reduce the amount of times we hit Zenodo for data downloads.