### PR TITLE
Add IGRF calculation

### DIFF
--- a/harmonica/_spherical_harmonics/igrf.py
+++ b/harmonica/_spherical_harmonics/igrf.py
@@ -1,0 +1,77 @@
+"""
+Calculation of the IGRF magnetic field.
+"""
+import pathlib
+import numpy as np
+import numba
+import xarray as xr
+from . import legendre
+from .._version import __version__
+
+import pooch
+import boule
+
+
+def fetch_igrf13():
+    """
+    """
+    path = pooch.retrieve(
+        url="doi:10.5281/zenodo.11269410/igrf13coeffs.txt",
+        path=pooch.os_cache("harmonica"),
+        known_hash="md5:e2e6e323086bde2dd910bb87d2db8532",
+    )
+    return path
+
+
+def load_igrf(path):
+    """
+    Load the IGRF Gauss coefficients from the given file
+    """
+    g, h, years = None, None, None
+    return g, h, years
+
+
+def interpolate_coefficients(date, g, h, years):
+    """
+    Interpolate the coefficients to the given date.
+    """
+    g_date, h_date = None, None
+    return g_date, h_date
+
+
+class IGRF13():
+    """
+    13th generation of the International Geomagnetic Reference Field
+    """
+
+    def __init__(self, date, ellipsoid=boule.WGS84):
+        self.date = date
+        path = fetch_igrf13()
+        g, h, years = load_igrf(path)
+        self._g, self._h = interpolate_coefficients(date, g, h, years)
+        self.reference_radius = 6371.2e3  # meters
+
+    @property
+    def dipole_moment(self):
+        """
+        Dipole moment of the Earth on a geocentric Cartesian system
+        """
+        return mx, my, mz
+
+    def predict(self, coordinates, field="b"):
+        """
+        Calculate the IGRF magnetic field at the given coordinates
+        """
+        latitude = coordinates[1]
+        longitude, latitude_sph, radius = self.ellipsoid.geodetic_to_spherical(
+            *coordinates
+        )
+        longitude = np.radians(longitude)
+        colatitude = np.radians(90 - latitude_sph)
+
+
+        return magnetic_field
+
+
+@numba.jit(nopython=True)
+def _cal

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -64,6 +64,54 @@ def assoc_legendre(x, max_degree):
 
 
 @numba.jit(nopython=True)
+def assoc_legendre_deriv(x, p):
+    """
+    Derivatives in theta of unnormalized associated Legendre functions.
+
+    Calculates the derivative:
+
+    .. math::
+
+        \\dfrac{\\partial P_n^m}{\\partial \\theta}(\\cos \\theta)
+
+    using the recursive relations defined in Alken (2022).
+
+    Higher-order derivatives can be calculated by passing the output of this
+    function as the ``p`` argument.
+
+    .. note::
+
+        This function does not include the Condon-Shortly phase.
+
+    Parameters
+    ----------
+    x : float
+        The argument of :math:`P_n^m(x)`. Must be in the range [-1, 1].
+    p : numpy.ndarray
+        A 2D array with the unnormalized associated Legendre functions
+        calculated for x.
+
+    Returns
+    -------
+    p_deriv : 2D numpy.array
+        Array with the values of the derivative with shape ``(max_degree + 1,
+        max_degree + 1)``. The degree n varies with the first axis and the
+        order m varies with the second axis. Array values where ``m > n`` are
+        set to ``numpy.nan``.
+
+    References
+    ----------
+
+    Alken, Patrick (2022). GSL Technical Report #1 - GSL-TR-001-20220827 -
+      Implementation of associated Legendre functions in GSL.
+      https://www.gnu.org/software/gsl/tr/tr001.pdf
+    """
+    max_degree = p.shape[0] + 1
+    p_deriv = np.full((max_degree + 1, max_degree + 1), np.nan)
+    return p
+
+
+@numba.jit(nopython=True)
 def assoc_legendre_schmidt(x, max_degree):
     """
     Schmidt normalized associated Legendre functions up to maximum degree.

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -108,7 +108,13 @@ def assoc_legendre_deriv(x, p):
     """
     max_degree = p.shape[0] + 1
     p_deriv = np.full((max_degree + 1, max_degree + 1), np.nan)
-    return p
+    p_deriv[0, 0] = 0
+    for n in range(1, max_degree + 1):
+        p_deriv[n, 0] = -p[n, 1]
+        for m in range(1, n):
+            p_deriv[n, m] = 0.5 * ((n + m) * (n - m + 1) * p[n, m - 1] - p[n, m + 1])
+        p_deriv[n, n] = n * p[n, n - 1]
+    return p_deriv
 
 
 @numba.jit(nopython=True)

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -1,0 +1,74 @@
+"""
+Calculation of associated Legendre functions and their derivatives.
+"""
+import numba
+import numpy as np
+import math
+
+
+def pnm(x, max_degree):
+    """
+    Calculate the associated Legendre functions Pnm until a maximum degree.
+
+    The functions :math:`P_n^m` are solutions to Legendre's equation. We
+    calculate their values using the recursive relations defined in
+    Alken (2022). This function does not include the Condon-Shortly phase.
+
+    Parameters
+    ----------
+    x : float
+        The argument of :math:`P_n^m(x)`. Must be in the range [-1, 1].
+    max_degree : int
+        The maximum degree for the calculation.
+
+
+    Returns
+    -------
+    p : 2D numpy.array
+        Array with the values of :math:`P_n^m(x)` with shape
+        ``(max_degree + 1, max_degree + 1)``. The degree n varies with the
+        first axis and the order m varies with the second axis. For example,
+        :math:`P_2^1(x)` is ``p[n, m]``. Array values where ``m > n`` are set
+        to ``numpy.nan``.
+
+    References
+    ----------
+
+    Alken, Patrick (2022). GSL Technical Report #1 - GSL-TR-001-20220827 -
+      Implementation of associated Legendre functions in GSL.
+      https://www.gnu.org/software/gsl/tr/tr001.pdf
+    """
+    p = np.full((max_degree + 1, max_degree + 1), np.nan)
+    sqrt_x = np.sqrt(1 - x**2)
+    p[0, 0] = 1
+    p[1, 0] = x
+    p[1, 1] = sqrt_x
+    _pnm_unnormalized(x, sqrt_x, max_degree, p)
+    return p
+
+
+@numba.jit(nopython=True)
+def _pnm_unnormalized(x, sqrt_x, max_degree, p):
+    "Optimized version of the unnormalized calculation."
+    for n in range(2, max_degree + 1):
+        for m in range(0, n - 1):
+            p[n, m] = ((2 * n - 1) * x * p[n-1, m] - (n + m - 1) * p[n-2, m]) / (n - m)
+        m = n - 1
+        p[n][m] = (2 * n - 1) / (n - m) * x * p[n - 1, m]
+        p[n][n] = (2 * n - 1) * sqrt_x * p[n - 1, n - 1]
+
+
+def schmidt_normalization(max_degree):
+    """
+    Calculate the Schmidt normalization factor for geomagnetic field models
+    """
+    s = np.full((max_degree + 1, max_degree + 1), np.nan)
+    for n in range(max_degree + 1):
+        for m in range(n + 1):
+            if m == 0:
+                s[n, m] = 1
+            else:
+                s[n, m] = np.sqrt(
+                    2 * math.factorial(n - m) / math.factorial(n + m)
+                )
+    return s

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -12,6 +12,17 @@ import numpy as np
 
 
 @numba.jit(nopython=True)
+def _rescale(u, max_degree, p):
+    "Rescale Legendre functions to their original range"
+    rescale = 1e280
+    for m in range(0, max_degree + 1):
+        if m > 0:
+            rescale *= u
+        for n in range(m, max_degree + 1):
+            p[n, m] *= rescale
+
+
+@numba.jit(nopython=True)
 def assoc_legendre(x, max_degree, p):
     """
     Unnormalized associated Legendre functions up to a maximum degree.
@@ -31,8 +42,8 @@ def assoc_legendre(x, max_degree, p):
     max_degree : int
         The maximum degree for the calculation.
     p : numpy.array
-        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
-        be filled with the output values.
+        A 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will be
+        filled with the output values.
 
     References
     ----------
@@ -41,7 +52,7 @@ def assoc_legendre(x, max_degree, p):
       Implementation of associated Legendre functions in GSL.
       https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
-    sqrt_x = np.sqrt(1 - x**2)
+    u = np.sqrt((1 - x) * (1 + x))
     p[0, 0] = 1
     for n in range(1, max_degree + 1):
         for m in range(0, n - 1):
@@ -51,12 +62,11 @@ def assoc_legendre(x, max_degree, p):
         c_nm = 2 * n - 1
         p[n, n - 1] = c_nm * x * p[n - 1, n - 1]
         d_nm = 2 * n - 1
-        p[n, n] = d_nm * sqrt_x * p[n - 1, n - 1]
-    return p
+        p[n, n] = d_nm * u * p[n - 1, n - 1]
 
 
 @numba.jit(nopython=True)
-def assoc_legendre_deriv(p, dp):
+def assoc_legendre_deriv(max_degree, p, dp):
     """
     Derivatives in theta of unnormalized associated Legendre functions.
 
@@ -77,12 +87,14 @@ def assoc_legendre_deriv(p, dp):
 
     Parameters
     ----------
+    max_degree : int
+        The maximum degree for the calculation.
     p : numpy.ndarray
         A 2D array with the unnormalized associated Legendre functions
         calculated for :math:`\\cos\\theta`.
     dp : numpy.array
-        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
-        be filled with the output values.
+        A 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will be
+        filled with the output values.
 
     References
     ----------
@@ -91,7 +103,6 @@ def assoc_legendre_deriv(p, dp):
       Implementation of associated Legendre functions in GSL.
       https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
-    max_degree = p.shape[0] - 1
     dp[0, 0] = 0
     for n in range(1, max_degree + 1):
         a_nm = -1
@@ -102,7 +113,6 @@ def assoc_legendre_deriv(p, dp):
             dp[n, m] = b_nm * p[n, m - 1] + c_nm * p[n, m + 1]
         d_nm = n
         dp[n, n] = d_nm * p[n, n - 1]
-    return dp
 
 
 @numba.jit(nopython=True)
@@ -124,7 +134,7 @@ def assoc_legendre_schmidt(x, max_degree, p):
     .. note::
 
         This function uses the scaling scheme of Holmes and Featherstone (2002)
-        and produces valid results until degree and order 2700.
+        and is tested until degree and order 2700.
 
     Parameters
     ----------
@@ -133,17 +143,8 @@ def assoc_legendre_schmidt(x, max_degree, p):
     max_degree : int
         The maximum degree for the calculation.
     p : numpy.array
-        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
-        be filled with the output values.
-
-    Returns
-    -------
-    p : 2D numpy.array
-        Array with the values of :math:`P_n^m(x)` with shape
-        ``(max_degree + 1, max_degree + 1)``. The degree n varies with the
-        first axis and the order m varies with the second axis. For example,
-        :math:`P_2^1(x)` is ``p[n, m]``. Array values where ``m > n`` are set
-        to ``numpy.nan``.
+        A 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will be
+        filled with the output values.
 
     References
     ----------
@@ -152,99 +153,21 @@ def assoc_legendre_schmidt(x, max_degree, p):
       Implementation of associated Legendre functions in GSL.
       https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
-    u = np.sqrt(1 - x**2)
+    u = np.sqrt((1 - x) * (1 + x))
     # Pre-compute square roots of integers used in the loops
     sqrt = np.sqrt(np.arange(2 * (max_degree + 1)))
-    # Calculate the scaled Pnm
-    _schmidt_scaled(x, max_degree, sqrt, p)
-    # Now return everything to the original range and rescale the by sqrt(x)**m
-    rescale = 1e280
-    for m in range(0, max_degree + 1):
-        if m > 0:
-            rescale *= u
-        for n in range(m, max_degree + 1):
-            p[n, m] *= rescale
-
-
-@numba.jit(nopython=True)
-def assoc_legendre_schmidt_deriv2(x, max_degree, p, dp, dp2):
-    """
-    Schmidt normalized associated Legendre functions up to maximum degree.
-
-    The functions :math:`P_n^m` are solutions to Legendre's equation. The
-    Schmidt normalization is applied to the functions to constrain their value
-    range. This normalization if often used in geomagnetic field models. We
-    calculate their values using the recursive relations defined in Alken
-    (2022).
-
-    .. note::
-
-        This function does not include the Condon-Shortly phase.
-
-
-    .. note::
-
-        This function uses the scaling scheme of Holmes and Featherstone (2002)
-        and produces valid results until degree and order 2700.
-
-    Parameters
-    ----------
-    x : float
-        The argument of :math:`P_n^m(x)`. Must be in the range [-1, 1].
-    max_degree : int
-        The maximum degree for the calculation.
-    p : numpy.array
-        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
-        be filled with the output values.
-
-    Returns
-    -------
-    p : 2D numpy.array
-        Array with the values of :math:`P_n^m(x)` with shape
-        ``(max_degree + 1, max_degree + 1)``. The degree n varies with the
-        first axis and the order m varies with the second axis. For example,
-        :math:`P_2^1(x)` is ``p[n, m]``. Array values where ``m > n`` are set
-        to ``numpy.nan``.
-
-    References
-    ----------
-
-    Alken, Patrick (2022). GSL Technical Report #1 - GSL-TR-001-20220827 -
-      Implementation of associated Legendre functions in GSL.
-      https://www.gnu.org/software/gsl/tr/tr001.pdf
-    """
-    u = np.sqrt(1 - x**2)
-    # Pre-compute square roots of integers used in the loops
-    sqrt = np.sqrt(np.arange(2 * (max_degree + 1)))
-    # Calculate the scaled Pnm
-    _schmidt_scaled(x, max_degree, sqrt, p)
-    # Now return everything to the original range and rescale the by sqrt(x)**m
-    rescale = 1e280
-    for m in range(0, max_degree + 1):
-        if m > 0:
-            rescale *= u
-        for n in range(m, max_degree + 1):
-            p[n, m] *= rescale
-    # Calculate the scaled first derivative
-    _schmidt_derivative(u, max_degree, sqrt, p, dp)
-    # Calculate the scaled second derivative
-    _schmidt_derivative(u, max_degree, sqrt, dp, dp2)
-
-
-@numba.jit(nopython=True)
-def _schmidt_scaled(x, max_degree, sqrt, p):
-    """
-    """
+    # Use the Holmes and Featherstone (2002) scaling to compute scaled Pnm
     # All terms are scaled by the max float range 1e280
-    # Calculate the zero order terms first
     p[0, 0] = 1 * 1e-280
     p[1, 0] = x * 1e-280
+    # This equation doesn't have u because of the scaling
+    p[1, 1] = p[0, 0]
+    # Calculate the zero order terms first
     for n in range(2, max_degree + 1):
         a_n0 = (2 * n - 1) / (sqrt[n] ** 2)
         b_n0 = -((sqrt[n - 1] / sqrt[n]) ** 2)
         p[n, 0] = a_n0 * x * p[n - 1, 0] + b_n0 * p[n - 2, 0]
-    # This equation doesn't have the sqrt(1 - x**2) because of the scaling
-    p[1, 1] = p[0, 0]
+    # Now calculate the other terms
     for n in range(2, max_degree + 1):
         for m in range(1, n - 1):
             a_nm = (2 * n - 1) / (sqrt[n + m] * sqrt[n - m])
@@ -253,34 +176,14 @@ def _schmidt_scaled(x, max_degree, sqrt, p):
         c_nm = sqrt[2 * n - 1]
         p[n, n - 1] = c_nm * x * p[n - 1, n - 1]
         d_nm = sqrt[2 * n - 1] / sqrt[2 * n]
-        # This equation doesn't have the sqrt(1 - x**2) because of the scaling
+        # This equation doesn't have u because of the scaling
         p[n, n] = d_nm * p[n - 1, n - 1]
+    # Now return everything to the original float range and rescale by u**m
+    _rescale(u, max_degree, p)
 
 
 @numba.jit(nopython=True)
-def _schmidt_derivative(u, max_degree, sqrt, p, dp):
-    """
-    Derivative of Schmidt normalized ALF
-    """
-    dp[0, 0] = 0
-    dp[1, 0] = -p[1, 1]
-    dp[1, 1] = p[1, 0]
-    for n in range(2, max_degree + 1):
-        a_nm = -sqrt[n] * sqrt[n + 1] / sqrt[2]
-        dp[n, 0] = a_nm * p[n, 1]
-        b_nm = 0.5 * sqrt[n] * sqrt[n + 1] * sqrt[2]
-        c_nm = -0.5 * sqrt[n + 2] * sqrt[n - 1]
-        dp[n, 1] = b_nm * p[n, 0] + c_nm * p[n, 2]
-        for m in range(2, n):
-            b_nm = 0.5 * sqrt[n + m] * sqrt[n - m + 1]
-            c_nm = -0.5 * sqrt[n + m + 1] * sqrt[n - m]
-            dp[n, m] = b_nm * p[n, m - 1] + c_nm * p[n, m + 1]
-        d_nm = 0.5 * sqrt[2] * sqrt[n]
-        dp[n, n] = d_nm * p[n, n - 1]
-
-
-@numba.jit(nopython=True)
-def assoc_legendre_schmidt_deriv(x, max_degree, p, dp):
+def assoc_legendre_schmidt_deriv(max_degree, p, dp):
     """
     Derivatives in theta of Schmidt normalized associated Legendre functions.
 
@@ -299,8 +202,14 @@ def assoc_legendre_schmidt_deriv(x, max_degree, p, dp):
 
         This function does not include the Condon-Shortly phase.
 
+    .. note::
+
+        This function is tested until degree 2700.
+
     Parameters
     ----------
+    max_degree : int
+        The maximum degree for the calculation.
     p : numpy.ndarray
         A 2D array with the Schmidt normalized associated Legendre functions
         calculated for :math:`\\cos\\theta`.
@@ -315,20 +224,23 @@ def assoc_legendre_schmidt_deriv(x, max_degree, p, dp):
       Implementation of associated Legendre functions in GSL.
       https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
-    u = np.sqrt(1 - x**2)
     # Pre-compute square roots of integers used in the loops
     sqrt = np.sqrt(np.arange(2 * (max_degree + 1)))
-    # Calculate the scaled Pnm
-    _schmidt_scaled(x, max_degree, sqrt, p)
-    # Now return everything to the original range and rescale the by sqrt(x)**m
-    rescale = 1e280
-    for m in range(0, max_degree + 1):
-        if m > 0:
-            rescale *= u
-        for n in range(m, max_degree + 1):
-            p[n, m] *= rescale
-    # Calculate the scaled first derivative
-    _schmidt_derivative(u, max_degree, sqrt, p, dp)
+    dp[0, 0] = 0
+    dp[1, 0] = -p[1, 1]
+    dp[1, 1] = p[1, 0]
+    for n in range(2, max_degree + 1):
+        a_nm = -sqrt[n] * sqrt[n + 1] / sqrt[2]
+        dp[n, 0] = a_nm * p[n, 1]
+        b_nm = 0.5 * sqrt[n] * sqrt[n + 1] * sqrt[2]
+        c_nm = -0.5 * sqrt[n + 2] * sqrt[n - 1]
+        dp[n, 1] = b_nm * p[n, 0] + c_nm * p[n, 2]
+        for m in range(2, n):
+            b_nm = 0.5 * sqrt[n + m] * sqrt[n - m + 1]
+            c_nm = -0.5 * sqrt[n + m + 1] * sqrt[n - m]
+            dp[n, m] = b_nm * p[n, m - 1] + c_nm * p[n, m + 1]
+        d_nm = 0.5 * sqrt[2] * sqrt[n]
+        dp[n, n] = d_nm * p[n, n - 1]
 
 
 @numba.jit(nopython=True)
@@ -352,8 +264,8 @@ def assoc_legendre_full(x, max_degree, p):
     max_degree : int
         The maximum degree for the calculation.
     p : numpy.array
-        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
-        be filled with the output values.
+        A 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will be
+        filled with the output values.
 
     References
     ----------
@@ -380,11 +292,10 @@ def assoc_legendre_full(x, max_degree, p):
         p[n, n - 1] = c_nm * x * p[n - 1, n - 1]
         d_nm = sqrt[2 * n + 1] / sqrt[2 * n]
         p[n, n] = d_nm * sqrt_x * p[n - 1, n - 1]
-    return p
 
 
 @numba.jit(nopython=True)
-def assoc_legendre_full_deriv(p, dp):
+def assoc_legendre_full_deriv(max_degree, p, dp):
     """
     Derivatives in theta of fully normalized associated Legendre functions.
 
@@ -405,12 +316,14 @@ def assoc_legendre_full_deriv(p, dp):
 
     Parameters
     ----------
+    max_degree : int
+        The maximum degree for the calculation.
     p : numpy.ndarray
         A 2D array with the fully normalized associated Legendre functions
         calculated for :math:`\\cos\\theta`.
     dp : numpy.array
-        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
-        be filled with the output values.
+        A 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will be
+        filled with the output values.
 
     References
     ----------
@@ -432,4 +345,3 @@ def assoc_legendre_full_deriv(p, dp):
             dp[n, m] = b_nm * p[n, m - 1] + c_nm * p[n, m + 1]
         d_nm = 0.5 * sqrt[2] * sqrt[n]
         dp[n, n] = d_nm * p[n, n - 1]
-    return dp

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -1,18 +1,30 @@
+# Copyright (c) 2018 The Harmonica Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
 """
 Calculation of associated Legendre functions and their derivatives.
 """
-import numba
-import numpy as np
 import math
 
+import numba
+import numpy as np
 
-def pnm(x, max_degree):
+
+@numba.jit(nopython=True)
+def assoc_legendre(x, max_degree):
     """
-    Calculate the associated Legendre functions Pnm until a maximum degree.
+    Unnormalized associated Legendre functions up to a maximum degree.
 
     The functions :math:`P_n^m` are solutions to Legendre's equation. We
-    calculate their values using the recursive relations defined in
-    Alken (2022). This function does not include the Condon-Shortly phase.
+    calculate their values using the recursive relations defined in Alken
+    (2022).
+
+    .. note::
+
+        This function does not include the Condon-Shortly phase.
 
     Parameters
     ----------
@@ -41,34 +53,128 @@ def pnm(x, max_degree):
     p = np.full((max_degree + 1, max_degree + 1), np.nan)
     sqrt_x = np.sqrt(1 - x**2)
     p[0, 0] = 1
-    p[1, 0] = x
-    p[1, 1] = sqrt_x
-    _pnm_unnormalized(x, sqrt_x, max_degree, p)
+    for n in range(1, max_degree + 1):
+        for m in range(0, n - 1):
+            a_nm = (2 * n - 1) / (n - m)
+            b_nm = -(n + m - 1) / (n - m)
+            p[n, m] = a_nm * x * p[n - 1, m] + b_nm * p[n - 2, m]
+        c_nm = 2 * n - 1
+        p[n][n - 1] = c_nm * x * p[n - 1, n - 1]
+        d_nm = 2 * n - 1
+        p[n][n] = d_nm * sqrt_x * p[n - 1, n - 1]
     return p
 
 
 @numba.jit(nopython=True)
-def _pnm_unnormalized(x, sqrt_x, max_degree, p):
-    "Optimized version of the unnormalized calculation."
-    for n in range(2, max_degree + 1):
+def assoc_legendre_schmidt(x, max_degree):
+    """
+    Schmidt normalized associated Legendre functions up to maximum degree.
+
+    The functions :math:`P_n^m` are solutions to Legendre's equation. The
+    Schmidt normalization is applied to the functions to constrain their value
+    range. This normalization if often used in geomagnetic field models. We
+    calculate their values using the recursive relations defined in Alken
+    (2022).
+
+    .. note::
+
+        This function does not include the Condon-Shortly phase.
+
+    Parameters
+    ----------
+    x : float
+        The argument of :math:`P_n^m(x)`. Must be in the range [-1, 1].
+    max_degree : int
+        The maximum degree for the calculation.
+
+
+    Returns
+    -------
+    p : 2D numpy.array
+        Array with the values of :math:`P_n^m(x)` with shape
+        ``(max_degree + 1, max_degree + 1)``. The degree n varies with the
+        first axis and the order m varies with the second axis. For example,
+        :math:`P_2^1(x)` is ``p[n, m]``. Array values where ``m > n`` are set
+        to ``numpy.nan``.
+
+    References
+    ----------
+
+    Alken, Patrick (2022). GSL Technical Report #1 - GSL-TR-001-20220827 -
+      Implementation of associated Legendre functions in GSL.
+      https://www.gnu.org/software/gsl/tr/tr001.pdf
+    """
+    p = np.full((max_degree + 1, max_degree + 1), np.nan)
+    sqrt_x = np.sqrt(1 - x**2)
+    p[0, 0] = 1
+    for n in range(1, max_degree + 1):
         for m in range(0, n - 1):
-            p[n, m] = ((2 * n - 1) * x * p[n-1, m] - (n + m - 1) * p[n-2, m]) / (n - m)
-        m = n - 1
-        p[n][m] = (2 * n - 1) / (n - m) * x * p[n - 1, m]
-        p[n][n] = (2 * n - 1) * sqrt_x * p[n - 1, n - 1]
+            a_nm = (2 * n - 1) / np.sqrt((n + m) * (n - m))
+            b_nm = -np.sqrt((n + m - 1) * (n - m - 1) / ((n + m) * (n - m)))
+            p[n, m] = a_nm * x * p[n - 1, m] + b_nm * p[n - 2, m]
+        c_nm = np.sqrt(2 * n - 1)
+        p[n][n - 1] = c_nm * x * p[n - 1, n - 1]
+        if n == 1:
+            d_nm = 1
+        else:
+            d_nm = np.sqrt(1 - 1 / (2 * n))
+        p[n][n] = d_nm * sqrt_x * p[n - 1, n - 1]
+    return p
 
 
-def schmidt_normalization(max_degree):
+@numba.jit(nopython=True)
+def assoc_legendre_full(x, max_degree):
     """
-    Calculate the Schmidt normalization factor for geomagnetic field models
+    Fully normalized associated Legendre functions up to maximum degree.
+
+    The functions :math:`P_n^m` are solutions to Legendre's equation. The full
+    normalization is applied to the functions to constrain their value range.
+    This normalization if often used in gravity field models. We calculate
+    their values using the recursive relations defined in Alken (2022).
+
+    .. note::
+
+        This function does not include the Condon-Shortly phase.
+
+    Parameters
+    ----------
+    x : float
+        The argument of :math:`P_n^m(x)`. Must be in the range [-1, 1].
+    max_degree : int
+        The maximum degree for the calculation.
+
+
+    Returns
+    -------
+    p : 2D numpy.array
+        Array with the values of :math:`P_n^m(x)` with shape
+        ``(max_degree + 1, max_degree + 1)``. The degree n varies with the
+        first axis and the order m varies with the second axis. For example,
+        :math:`P_2^1(x)` is ``p[n, m]``. Array values where ``m > n`` are set
+        to ``numpy.nan``.
+
+    References
+    ----------
+
+    Alken, Patrick (2022). GSL Technical Report #1 - GSL-TR-001-20220827 -
+      Implementation of associated Legendre functions in GSL.
+      https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
-    s = np.full((max_degree + 1, max_degree + 1), np.nan)
-    for n in range(max_degree + 1):
-        for m in range(n + 1):
-            if m == 0:
-                s[n, m] = 1
-            else:
-                s[n, m] = np.sqrt(
-                    2 * math.factorial(n - m) / math.factorial(n + m)
-                )
-    return s
+    p = np.full((max_degree + 1, max_degree + 1), np.nan)
+    sqrt_x = np.sqrt(1 - x**2)
+    p[0, 0] = np.sqrt(0.5)
+    for n in range(1, max_degree + 1):
+        for m in range(0, n - 1):
+            a_nm = np.sqrt((2 * n + 1) * (2 * n - 1) / ((n + m) * (n - m)))
+            b_nm = -np.sqrt(
+                (n + m - 1)
+                * (n - m - 1)
+                * (2 * n + 1)
+                / ((n + m) * (n - m) * (2 * n - 3))
+            )
+            p[n, m] = a_nm * x * p[n - 1, m] + b_nm * p[n - 2, m]
+        c_nm = np.sqrt(2 * n + 1)
+        p[n][n - 1] = c_nm * x * p[n - 1, n - 1]
+        d_nm = np.sqrt(1 + 1 / (2 * n))
+        p[n][n] = d_nm * sqrt_x * p[n - 1, n - 1]
+    return p

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -7,8 +7,6 @@
 """
 Calculation of associated Legendre functions and their derivatives.
 """
-import math
-
 import numba
 import numpy as np
 

--- a/harmonica/_spherical_harmonics/legendre.py
+++ b/harmonica/_spherical_harmonics/legendre.py
@@ -152,20 +152,99 @@ def assoc_legendre_schmidt(x, max_degree, p):
       Implementation of associated Legendre functions in GSL.
       https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
+    u = np.sqrt(1 - x**2)
     # Pre-compute square roots of integers used in the loops
     sqrt = np.sqrt(np.arange(2 * (max_degree + 1)))
-    sqrt_x = np.sqrt(1 - x**2)
-    # Calculate the zero order terms first because they are not scaled to
-    # preserve numerical stability
-    p[0, 0] = 1
-    p[1, 0] = x
+    # Calculate the scaled Pnm
+    _schmidt_scaled(x, max_degree, sqrt, p)
+    # Now return everything to the original range and rescale the by sqrt(x)**m
+    rescale = 1e280
+    for m in range(0, max_degree + 1):
+        if m > 0:
+            rescale *= u
+        for n in range(m, max_degree + 1):
+            p[n, m] *= rescale
+
+
+@numba.jit(nopython=True)
+def assoc_legendre_schmidt_deriv2(x, max_degree, p, dp, dp2):
+    """
+    Schmidt normalized associated Legendre functions up to maximum degree.
+
+    The functions :math:`P_n^m` are solutions to Legendre's equation. The
+    Schmidt normalization is applied to the functions to constrain their value
+    range. This normalization if often used in geomagnetic field models. We
+    calculate their values using the recursive relations defined in Alken
+    (2022).
+
+    .. note::
+
+        This function does not include the Condon-Shortly phase.
+
+
+    .. note::
+
+        This function uses the scaling scheme of Holmes and Featherstone (2002)
+        and produces valid results until degree and order 2700.
+
+    Parameters
+    ----------
+    x : float
+        The argument of :math:`P_n^m(x)`. Must be in the range [-1, 1].
+    max_degree : int
+        The maximum degree for the calculation.
+    p : numpy.array
+        An 2D array with shape ``(max_degree + 1, max_degree + 1)`` that will
+        be filled with the output values.
+
+    Returns
+    -------
+    p : 2D numpy.array
+        Array with the values of :math:`P_n^m(x)` with shape
+        ``(max_degree + 1, max_degree + 1)``. The degree n varies with the
+        first axis and the order m varies with the second axis. For example,
+        :math:`P_2^1(x)` is ``p[n, m]``. Array values where ``m > n`` are set
+        to ``numpy.nan``.
+
+    References
+    ----------
+
+    Alken, Patrick (2022). GSL Technical Report #1 - GSL-TR-001-20220827 -
+      Implementation of associated Legendre functions in GSL.
+      https://www.gnu.org/software/gsl/tr/tr001.pdf
+    """
+    u = np.sqrt(1 - x**2)
+    # Pre-compute square roots of integers used in the loops
+    sqrt = np.sqrt(np.arange(2 * (max_degree + 1)))
+    # Calculate the scaled Pnm
+    _schmidt_scaled(x, max_degree, sqrt, p)
+    # Now return everything to the original range and rescale the by sqrt(x)**m
+    rescale = 1e280
+    for m in range(0, max_degree + 1):
+        if m > 0:
+            rescale *= u
+        for n in range(m, max_degree + 1):
+            p[n, m] *= rescale
+    # Calculate the scaled first derivative
+    _schmidt_derivative(u, max_degree, sqrt, p, dp)
+    # Calculate the scaled second derivative
+    _schmidt_derivative(u, max_degree, sqrt, dp, dp2)
+
+
+@numba.jit(nopython=True)
+def _schmidt_scaled(x, max_degree, sqrt, p):
+    """
+    """
+    # All terms are scaled by the max float range 1e280
+    # Calculate the zero order terms first
+    p[0, 0] = 1 * 1e-280
+    p[1, 0] = x * 1e-280
     for n in range(2, max_degree + 1):
         a_n0 = (2 * n - 1) / (sqrt[n] ** 2)
         b_n0 = -((sqrt[n - 1] / sqrt[n]) ** 2)
         p[n, 0] = a_n0 * x * p[n - 1, 0] + b_n0 * p[n - 2, 0]
-    # Start the following terms with P1,1 scaled (divided by sqrt(x) and 1e280
-    # which the 64bit floating point range)
-    p[1, 1] = p[0, 0] * 1e-280
+    # This equation doesn't have the sqrt(1 - x**2) because of the scaling
+    p[1, 1] = p[0, 0]
     for n in range(2, max_degree + 1):
         for m in range(1, n - 1):
             a_nm = (2 * n - 1) / (sqrt[n + m] * sqrt[n - m])
@@ -174,19 +253,34 @@ def assoc_legendre_schmidt(x, max_degree, p):
         c_nm = sqrt[2 * n - 1]
         p[n, n - 1] = c_nm * x * p[n - 1, n - 1]
         d_nm = sqrt[2 * n - 1] / sqrt[2 * n]
-        # This equation doesn't have the sqrt(x) because of the scaling
+        # This equation doesn't have the sqrt(1 - x**2) because of the scaling
         p[n, n] = d_nm * p[n - 1, n - 1]
-    # Now return everything to the original range and rescale the by sqrt(x)**m
-    rescale = 1e280
-    for m in range(1, max_degree + 1):
-        rescale *= sqrt_x
-        for n in range(m, max_degree + 1):
-            p[n, m] *= rescale
-    return p
 
 
 @numba.jit(nopython=True)
-def assoc_legendre_schmidt_deriv(p, dp):
+def _schmidt_derivative(u, max_degree, sqrt, p, dp):
+    """
+    Derivative of Schmidt normalized ALF
+    """
+    dp[0, 0] = 0
+    dp[1, 0] = -p[1, 1]
+    dp[1, 1] = p[1, 0]
+    for n in range(2, max_degree + 1):
+        a_nm = -sqrt[n] * sqrt[n + 1] / sqrt[2]
+        dp[n, 0] = a_nm * p[n, 1]
+        b_nm = 0.5 * sqrt[n] * sqrt[n + 1] * sqrt[2]
+        c_nm = -0.5 * sqrt[n + 2] * sqrt[n - 1]
+        dp[n, 1] = b_nm * p[n, 0] + c_nm * p[n, 2]
+        for m in range(2, n):
+            b_nm = 0.5 * sqrt[n + m] * sqrt[n - m + 1]
+            c_nm = -0.5 * sqrt[n + m + 1] * sqrt[n - m]
+            dp[n, m] = b_nm * p[n, m - 1] + c_nm * p[n, m + 1]
+        d_nm = 0.5 * sqrt[2] * sqrt[n]
+        dp[n, n] = d_nm * p[n, n - 1]
+
+
+@numba.jit(nopython=True)
+def assoc_legendre_schmidt_deriv(x, max_degree, p, dp):
     """
     Derivatives in theta of Schmidt normalized associated Legendre functions.
 
@@ -221,25 +315,20 @@ def assoc_legendre_schmidt_deriv(p, dp):
       Implementation of associated Legendre functions in GSL.
       https://www.gnu.org/software/gsl/tr/tr001.pdf
     """
-    max_degree = p.shape[0] - 1
+    u = np.sqrt(1 - x**2)
     # Pre-compute square roots of integers used in the loops
     sqrt = np.sqrt(np.arange(2 * (max_degree + 1)))
-    dp[0, 0] = 0
-    dp[1, 0] = -p[1, 1]
-    dp[1, 1] = p[1, 0]
-    for n in range(2, max_degree + 1):
-        a_nm = -sqrt[n] * sqrt[n + 1] / sqrt[2]
-        dp[n, 0] = a_nm * p[n, 1]
-        b_nm = 0.5 * sqrt[n] * sqrt[n + 1] * sqrt[2]
-        c_nm = -0.5 * sqrt[n + 2] * sqrt[n - 1]
-        dp[n, 1] = b_nm * p[n, 0] + c_nm * p[n, 2]
-        for m in range(2, n):
-            b_nm = 0.5 * sqrt[n + m] * sqrt[n - m + 1]
-            c_nm = -0.5 * sqrt[n + m + 1] * sqrt[n - m]
-            dp[n, m] = b_nm * p[n, m - 1] + c_nm * p[n, m + 1]
-        d_nm = 0.5 * sqrt[2] * sqrt[n]
-        dp[n, n] = d_nm * p[n, n - 1]
-    return dp
+    # Calculate the scaled Pnm
+    _schmidt_scaled(x, max_degree, sqrt, p)
+    # Now return everything to the original range and rescale the by sqrt(x)**m
+    rescale = 1e280
+    for m in range(0, max_degree + 1):
+        if m > 0:
+            rescale *= u
+        for n in range(m, max_degree + 1):
+            p[n, m] *= rescale
+    # Calculate the scaled first derivative
+    _schmidt_derivative(u, max_degree, sqrt, p, dp)
 
 
 @numba.jit(nopython=True)

--- a/harmonica/filters/_fft.py
+++ b/harmonica/filters/_fft.py
@@ -79,5 +79,5 @@ def ifft(fourier_transform, true_phase=True, true_amplitude=True, **kwargs):
         fourier_transform,
         true_phase=true_phase,
         true_amplitude=true_amplitude,
-        **kwargs
+        **kwargs,
     )

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -21,6 +21,9 @@ from .._spherical_harmonics.legendre import (
 )
 
 
+# Fixtures
+# #############################################################################
+
 def legendre_analytical(x):
     "Analytical expressions for unnormalized Legendre functions"
     max_degree = 4
@@ -93,6 +96,11 @@ def full_normalization(max_degree):
     return s
 
 
+# Tests
+# #############################################################################
+
+# Unnormalized
+# -----------------------------------------------------------------------------
 def test_assoc_legendre():
     "Check if the first few degrees match analytical expressions"
     for angle in np.linspace(0, np.pi, 360):
@@ -106,56 +114,6 @@ def test_assoc_legendre():
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(p_analytical[n, m], p[n, m], atol=1e-10)
-
-
-def test_assoc_legendre_schmidt():
-    "Check if the first few degrees match analytical expressions"
-    for angle in np.linspace(0, np.pi, 360):
-        x = np.cos(angle)
-        # Analytical expression
-        p_analytical_unnormalized = legendre_analytical(x)
-        max_degree = p_analytical_unnormalized.shape[0] - 1
-        s = schmidt_normalization(max_degree)
-        p_analytical = s * p_analytical_unnormalized
-        # Numerical calculation
-        p = np.empty((max_degree + 1, max_degree + 1))
-        assoc_legendre_schmidt(x, max_degree, p)
-        for n in range(max_degree + 1):
-            for m in range(n + 1):
-                np.testing.assert_allclose(
-                    p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
-                )
-
-
-def test_assoc_legendre_full():
-    "Check if the first few degrees match analytical expressions"
-    for angle in np.linspace(0, np.pi, 360):
-        x = np.cos(angle)
-        # Analytical expression
-        p_analytical_unnormalized = legendre_analytical(x)
-        max_degree = p_analytical_unnormalized.shape[0] - 1
-        s = full_normalization(max_degree)
-        p_analytical = s * p_analytical_unnormalized
-        # Numerical calculation
-        p = np.empty((max_degree + 1, max_degree + 1))
-        assoc_legendre_full(x, max_degree, p)
-        for n in range(max_degree + 1):
-            for m in range(n + 1):
-                np.testing.assert_allclose(
-                    p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
-                )
-
-
-def test_assoc_legengre_schmidt_identity():
-    "Check Schmidt normalized functions against a known identity"
-    # Higher degrees than this yield bad results
-    max_degree = 2800
-    # The sum of the coefs squared for a degree should be 1
-    true_value = np.ones(max_degree + 1)
-    p = np.zeros((max_degree + 1, max_degree + 1))
-    for x in np.linspace(-1, 1, 100):
-        assoc_legendre_schmidt(x, max_degree, p)
-        np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-10, rtol=0)
 
 
 def test_assoc_legendre_deriv():
@@ -174,6 +132,28 @@ def test_assoc_legendre_deriv():
             for m in range(n + 1):
                 np.testing.assert_allclose(
                     p_analytical[n, m], dp[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
+                )
+
+# Schmidt
+# -----------------------------------------------------------------------------
+
+
+def test_assoc_legendre_schmidt():
+    "Check if the first few degrees match analytical expressions"
+    for angle in np.linspace(0, np.pi, 360):
+        x = np.cos(angle)
+        # Analytical expression
+        p_analytical_unnormalized = legendre_analytical(x)
+        max_degree = p_analytical_unnormalized.shape[0] - 1
+        s = schmidt_normalization(max_degree)
+        p_analytical = s * p_analytical_unnormalized
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_schmidt(x, max_degree, p)
+        for n in range(max_degree + 1):
+            for m in range(n + 1):
+                np.testing.assert_allclose(
+                    p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
 
 
@@ -198,6 +178,40 @@ def test_assoc_legendre_schmidt_deriv():
                 )
 
 
+def test_assoc_legengre_schmidt_identity():
+    "Check Schmidt normalized functions against a known identity"
+    # Higher degrees than this yield bad results
+    max_degree = 2800
+    # The sum of the coefs squared for a degree should be 1
+    true_value = np.ones(max_degree + 1)
+    p = np.zeros((max_degree + 1, max_degree + 1))
+    for x in np.linspace(-1, 1, 50):
+        assoc_legendre_schmidt(x, max_degree, p)
+        np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-10, rtol=0)
+
+
+# Full
+# -----------------------------------------------------------------------------
+
+def test_assoc_legendre_full():
+    "Check if the first few degrees match analytical expressions"
+    for angle in np.linspace(0, np.pi, 360):
+        x = np.cos(angle)
+        # Analytical expression
+        p_analytical_unnormalized = legendre_analytical(x)
+        max_degree = p_analytical_unnormalized.shape[0] - 1
+        s = full_normalization(max_degree)
+        p_analytical = s * p_analytical_unnormalized
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_full(x, max_degree, p)
+        for n in range(max_degree + 1):
+            for m in range(n + 1):
+                np.testing.assert_allclose(
+                    p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
+                )
+
+
 def test_assoc_legendre_full_deriv():
     "Check if the first few degrees match analytical expressions"
     for angle in np.linspace(0, np.pi, 360):
@@ -217,3 +231,26 @@ def test_assoc_legendre_full_deriv():
                 np.testing.assert_allclose(
                     p_analytical[n, m], dp[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
+
+
+def test_assoc_legengre_legendre_equation():
+    "Check functions and derivatives against the Legendre equation"
+    max_degree = 2700
+    # Legendre equation should result in 0
+    true_value = np.zeros((max_degree + 1, max_degree + 1))
+    p = np.zeros((max_degree + 1, max_degree + 1))
+    dp = np.zeros((max_degree + 1, max_degree + 1))
+    dp2 = np.zeros((max_degree + 1, max_degree + 1))
+    index = np.arange(max_degree + 1).reshape((max_degree  +1, 1))
+    n = np.repeat(index, max_degree + 1, axis=1)
+    m = np.repeat(index.T, max_degree + 1, axis=0)
+    for angle in np.linspace(0.001, np.pi - 0.001, 180):
+        cos = np.cos(angle)
+        sin = np.sin(angle)
+        sin2 = np.sin(angle * n * (n+1))
+        assoc_legendre_schmidt(cos, max_degree, p)
+        assoc_legendre_schmidt_deriv(p, dp)
+        assoc_legendre_schmidt_deriv(dp, dp2)
+
+        legendre = sin * dp2 + cos*dp + (sin2 - m**2/sin)*p
+        np.testing.assert_allclose(legendre, true_value, atol=1e-8, rtol=0)

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -1,45 +1,114 @@
+# Copyright (c) 2018 The Harmonica Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
 """
 Test the associated Legendre function calculations.
 """
+import math
+
 import numpy as np
 
-from .._spherical_harmonics.legendre import pnm
+from .._spherical_harmonics.legendre import (
+    assoc_legendre,
+    assoc_legendre_full,
+    assoc_legendre_schmidt,
+)
 
 
-def test_legendre_pnm_unnormalized():
+def legendre_analytical(x):
+    "Analytical expressions for unnormalized Legendre functions"
+    max_degree = 4
+    p = np.full((max_degree + 1, max_degree + 1), np.nan)
+    p[0, 0] = 1
+    p[1, 0] = x
+    p[1, 1] = np.sqrt(1 - x**2)
+    p[2, 0] = 1 / 2 * (3 * x**2 - 1)
+    p[2, 1] = 3 * x * np.sqrt(1 - x**2)
+    p[2, 2] = 3 * (1 - x**2)
+    p[3, 0] = 1 / 2 * (5 * x**3 - 3 * x)
+    p[3, 1] = -3 / 2 * (1 - 5 * x**2) * np.sqrt(1 - x**2)
+    p[3, 2] = 15 * x * (1 - x**2)
+    p[3, 3] = 15 * np.sqrt(1 - x**2) ** 3
+    p[4, 0] = 1 / 8 * (35 * x**4 - 30 * x**2 + 3)
+    p[4, 1] = 5 / 2 * (7 * x**3 - 3 * x) * np.sqrt(1 - x**2)
+    p[4, 2] = 15 / 2 * (7 * x**2 - 1) * (1 - x**2)
+    p[4, 3] = 105 * x * np.sqrt(1 - x**2) ** 3
+    p[4, 4] = 105 * np.sqrt(1 - x**2) ** 4
+    return p
+
+
+def schmidt_normalization(max_degree):
+    "Calculate the Schmidt normalization factor"
+    s = np.full((max_degree + 1, max_degree + 1), np.nan)
+    for n in range(max_degree + 1):
+        for m in range(n + 1):
+            if m == 0:
+                s[n, m] = 1
+            else:
+                s[n, m] = np.sqrt(2 * math.factorial(n - m) / math.factorial(n + m))
+    return s
+
+
+def full_normalization(max_degree):
+    "Calculate the full normalization factor"
+    s = np.full((max_degree + 1, max_degree + 1), np.nan)
+    for n in range(max_degree + 1):
+        for m in range(n + 1):
+            s[n, m] = np.sqrt((n + 0.5) * math.factorial(n - m) / math.factorial(n + m))
+    return s
+
+
+def test_legendre_assoc_legendre():
     "Check if the first few degrees match analytical expressions"
     for angle in np.linspace(0, np.pi, 180):
         x = np.cos(angle)
-        p = pnm(x, 4)
-        # Make sure the upper diagonal is all NaNs
-        for n in range(p.shape[0]):
-            for m in range(n + 1, p.shape[1]):
+        p_analytical = legendre_analytical(x)
+        max_degree = p_analytical.shape[0] - 1
+        p = assoc_legendre(x, max_degree)
+        for n in range(max_degree + 1):
+            for m in range(n + 1):
+                np.testing.assert_allclose(p_analytical[n, m], p[n, m], atol=1e-10)
+            # Make sure the upper diagonal is all NaNs
+            for m in range(n + 1, max_degree + 1):
                 assert np.isnan(p[n, m])
-        # Degree 0
-        np.testing.assert_allclose(1, p[0][0])
-        # Degree 1
-        np.testing.assert_allclose(x, p[1][0])
-        np.testing.assert_allclose(np.sqrt(1 - x**2), p[1][1], atol=1e-10)
-        # Degree 2
-        np.testing.assert_allclose(1 / 2 * (3 * x**2 - 1), p[2][0], atol=1e-10)
-        np.testing.assert_allclose(3 * x * np.sqrt(1 - x**2), p[2][1], atol=1e-10)
-        np.testing.assert_allclose(3 * (1 - x**2), p[2][2], atol=1e-10)
-        # Degree 3
-        np.testing.assert_allclose(1 / 2 * (5 * x**3 - 3 * x), p[3][0], atol=1e-10)
-        np.testing.assert_allclose(
-            -3 / 2 * (1 - 5 * x**2) * np.sqrt(1 - x**2), p[3][1], atol=1e-10
-        )
-        np.testing.assert_allclose(15 * x * (1 - x**2), p[3][2], atol=1e-10)
-        np.testing.assert_allclose(15 * np.sqrt(1 - x**2) ** 3, p[3][3], atol=1e-10)
-        # Degree 4
-        np.testing.assert_allclose(
-            1 / 8 * (35 * x**4 - 30 * x**2 + 3), p[4][0], atol=1e-10
-        )
-        np.testing.assert_allclose(
-            5 / 2 * (7 * x**3 - 3 * x) * np.sqrt(1 - x**2), p[4][1], atol=1e-10
-        )
-        np.testing.assert_allclose(
-            15 / 2 * (7 * x**2 - 1) * (1 - x**2), p[4][2], atol=1e-10
-        )
-        np.testing.assert_allclose(105 * x * np.sqrt(1 - x**2) ** 3, p[4][3], atol=1e-10)
-        np.testing.assert_allclose(105 * np.sqrt(1 - x**2) ** 4, p[4][4], atol=1e-10)
+
+
+def test_legendre_assoc_legendre_schmidt():
+    "Check if the first few degrees match analytical expressions"
+    for angle in np.linspace(0, np.pi, 180):
+        x = np.cos(angle)
+        p_analytical_unnormalized = legendre_analytical(x)
+        max_degree = p_analytical_unnormalized.shape[0] - 1
+        s = schmidt_normalization(max_degree)
+        p_analytical = s * p_analytical_unnormalized
+        p = assoc_legendre_schmidt(x, max_degree)
+        for n in range(max_degree + 1):
+            for m in range(n + 1):
+                np.testing.assert_allclose(
+                    p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
+                )
+            # Make sure the upper diagonal is all NaNs
+            for m in range(n + 1, max_degree + 1):
+                assert np.isnan(p[n, m])
+
+
+def test_legendre_assoc_legendre_full():
+    "Check if the first few degrees match analytical expressions"
+    for angle in np.linspace(0, np.pi, 180):
+        x = np.cos(angle)
+        p_analytical_unnormalized = legendre_analytical(x)
+        max_degree = p_analytical_unnormalized.shape[0] - 1
+        s = full_normalization(max_degree)
+        p_analytical = s * p_analytical_unnormalized
+        p = assoc_legendre_full(x, max_degree)
+        for n in range(max_degree + 1):
+            for m in range(n + 1):
+                np.testing.assert_allclose(
+                    p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
+                )
+            # Make sure the upper diagonal is all NaNs
+            for m in range(n + 1, max_degree + 1):
+                assert np.isnan(p[n, m])

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -155,7 +155,7 @@ def test_assoc_legengre_schmidt_identity():
     p = np.zeros((max_degree + 1, max_degree + 1))
     for x in np.linspace(-1, 1, 100):
         assoc_legendre_schmidt(x, max_degree, p)
-        np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-11, rtol=0)
+        np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-10, rtol=0)
 
 
 def test_assoc_legendre_deriv():

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -1,0 +1,45 @@
+"""
+Test the associated Legendre function calculations.
+"""
+import numpy as np
+
+from .._spherical_harmonics.legendre import pnm
+
+
+def test_legendre_pnm_unnormalized():
+    "Check if the first few degrees match analytical expressions"
+    for angle in np.linspace(0, np.pi, 180):
+        x = np.cos(angle)
+        p = pnm(x, 4)
+        # Make sure the upper diagonal is all NaNs
+        for n in range(p.shape[0]):
+            for m in range(n + 1, p.shape[1]):
+                assert np.isnan(p[n, m])
+        # Degree 0
+        np.testing.assert_allclose(1, p[0][0])
+        # Degree 1
+        np.testing.assert_allclose(x, p[1][0])
+        np.testing.assert_allclose(np.sqrt(1 - x**2), p[1][1], atol=1e-10)
+        # Degree 2
+        np.testing.assert_allclose(1 / 2 * (3 * x**2 - 1), p[2][0], atol=1e-10)
+        np.testing.assert_allclose(3 * x * np.sqrt(1 - x**2), p[2][1], atol=1e-10)
+        np.testing.assert_allclose(3 * (1 - x**2), p[2][2], atol=1e-10)
+        # Degree 3
+        np.testing.assert_allclose(1 / 2 * (5 * x**3 - 3 * x), p[3][0], atol=1e-10)
+        np.testing.assert_allclose(
+            -3 / 2 * (1 - 5 * x**2) * np.sqrt(1 - x**2), p[3][1], atol=1e-10
+        )
+        np.testing.assert_allclose(15 * x * (1 - x**2), p[3][2], atol=1e-10)
+        np.testing.assert_allclose(15 * np.sqrt(1 - x**2) ** 3, p[3][3], atol=1e-10)
+        # Degree 4
+        np.testing.assert_allclose(
+            1 / 8 * (35 * x**4 - 30 * x**2 + 3), p[4][0], atol=1e-10
+        )
+        np.testing.assert_allclose(
+            5 / 2 * (7 * x**3 - 3 * x) * np.sqrt(1 - x**2), p[4][1], atol=1e-10
+        )
+        np.testing.assert_allclose(
+            15 / 2 * (7 * x**2 - 1) * (1 - x**2), p[4][2], atol=1e-10
+        )
+        np.testing.assert_allclose(105 * x * np.sqrt(1 - x**2) ** 3, p[4][3], atol=1e-10)
+        np.testing.assert_allclose(105 * np.sqrt(1 - x**2) ** 4, p[4][4], atol=1e-10)

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -15,9 +15,9 @@ from .._spherical_harmonics.legendre import (
     assoc_legendre,
     assoc_legendre_deriv,
     assoc_legendre_full,
+    assoc_legendre_full_deriv,
     assoc_legendre_schmidt,
     assoc_legendre_schmidt_deriv,
-    assoc_legendre_full_deriv,
 )
 
 
@@ -44,7 +44,10 @@ def legendre_analytical(x):
 
 
 def legendre_derivative_analytical(x):
-    "Analytical expressions for theta derivatives unnormalized Legendre functions"
+    """
+    Analytical expressions for theta derivatives of unnormalized Legendre
+    functions
+    """
     max_degree = 4
     dp = np.full((max_degree + 1, max_degree + 1), np.nan)
     cos = x
@@ -92,64 +95,66 @@ def full_normalization(max_degree):
 
 def test_assoc_legendre():
     "Check if the first few degrees match analytical expressions"
-    for angle in np.linspace(0, np.pi, 180):
+    for angle in np.linspace(0, np.pi, 360):
         x = np.cos(angle)
+        # Analytical expression
         p_analytical = legendre_analytical(x)
         max_degree = p_analytical.shape[0] - 1
-        p = assoc_legendre(x, max_degree)
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre(x, max_degree, p)
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(p_analytical[n, m], p[n, m], atol=1e-10)
-            # Make sure the upper diagonal is all NaNs
-            for m in range(n + 1, max_degree + 1):
-                assert np.isnan(p[n, m])
 
 
 def test_assoc_legendre_schmidt():
     "Check if the first few degrees match analytical expressions"
-    for angle in np.linspace(0, np.pi, 180):
+    for angle in np.linspace(0, np.pi, 360):
         x = np.cos(angle)
+        # Analytical expression
         p_analytical_unnormalized = legendre_analytical(x)
         max_degree = p_analytical_unnormalized.shape[0] - 1
         s = schmidt_normalization(max_degree)
         p_analytical = s * p_analytical_unnormalized
-        p = assoc_legendre_schmidt(x, max_degree)
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_schmidt(x, max_degree, p)
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(
                     p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
-            # Make sure the upper diagonal is all NaNs
-            for m in range(n + 1, max_degree + 1):
-                assert np.isnan(p[n, m])
 
 
 def test_assoc_legendre_full():
     "Check if the first few degrees match analytical expressions"
-    for angle in np.linspace(0, np.pi, 180):
+    for angle in np.linspace(0, np.pi, 360):
         x = np.cos(angle)
+        # Analytical expression
         p_analytical_unnormalized = legendre_analytical(x)
         max_degree = p_analytical_unnormalized.shape[0] - 1
         s = full_normalization(max_degree)
         p_analytical = s * p_analytical_unnormalized
-        p = assoc_legendre_full(x, max_degree)
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_full(x, max_degree, p)
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(
                     p_analytical[n, m], p[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
-            # Make sure the upper diagonal is all NaNs
-            for m in range(n + 1, max_degree + 1):
-                assert np.isnan(p[n, m])
 
 
 def test_assoc_legengre_schmidt_identity():
     "Check Schmidt normalized functions against a known identity"
     # Higher degrees than this yield bad results
     max_degree = 600
+    # The sum of the coefs squared for a degree should be 1
     true_value = np.ones(max_degree + 1)
+    p = np.empty((max_degree + 1, max_degree + 1))
     for x in np.linspace(-1, 1, 100):
-        p = assoc_legendre_schmidt(x, max_degree)
+        assoc_legendre_schmidt(x, max_degree, p)
         p[np.isnan(p)] = 0
         np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-12)
 
@@ -158,55 +163,58 @@ def test_assoc_legendre_deriv():
     "Check if the first few degrees match analytical expressions"
     for angle in np.linspace(0, np.pi, 360):
         x = np.cos(angle)
+        # Analytical expression
         p_analytical = legendre_derivative_analytical(x)
         max_degree = p_analytical.shape[0] - 1
-        p = assoc_legendre(x, max_degree)
-        dp = assoc_legendre_deriv(x, p)
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre(x, max_degree, p)
+        dp = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_deriv(p, dp)
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(
                     p_analytical[n, m], dp[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
-            # Make sure the upper diagonal is all NaNs
-            for m in range(n + 1, max_degree + 1):
-                assert np.isnan(dp[n, m])
 
 
 def test_assoc_legendre_schmidt_deriv():
     "Check if the first few degrees match analytical expressions"
     for angle in np.linspace(0, np.pi, 360):
         x = np.cos(angle)
+        # Analytical expression
         p_analytical_unnormalized = legendre_derivative_analytical(x)
         max_degree = p_analytical_unnormalized.shape[0] - 1
         s = schmidt_normalization(max_degree)
         p_analytical = s * p_analytical_unnormalized
-        p = assoc_legendre_schmidt(x, max_degree)
-        dp = assoc_legendre_schmidt_deriv(x, p)
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_schmidt(x, max_degree, p)
+        dp = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_schmidt_deriv(p, dp)
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(
                     p_analytical[n, m], dp[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
-            # Make sure the upper diagonal is all NaNs
-            for m in range(n + 1, max_degree + 1):
-                assert np.isnan(dp[n, m])
 
 
 def test_assoc_legendre_full_deriv():
     "Check if the first few degrees match analytical expressions"
     for angle in np.linspace(0, np.pi, 360):
         x = np.cos(angle)
+        # Analytical expression
         p_analytical_unnormalized = legendre_derivative_analytical(x)
         max_degree = p_analytical_unnormalized.shape[0] - 1
         s = full_normalization(max_degree)
         p_analytical = s * p_analytical_unnormalized
-        p = assoc_legendre_full(x, max_degree)
-        dp = assoc_legendre_full_deriv(x, p)
+        # Numerical calculation
+        p = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_full(x, max_degree, p)
+        dp = np.empty((max_degree + 1, max_degree + 1))
+        assoc_legendre_full_deriv(p, dp)
         for n in range(max_degree + 1):
             for m in range(n + 1):
                 np.testing.assert_allclose(
                     p_analytical[n, m], dp[n, m], atol=1e-10, err_msg=f"n={n}, m={m}"
                 )
-            # Make sure the upper diagonal is all NaNs
-            for m in range(n + 1, max_degree + 1):
-                assert np.isnan(dp[n, m])

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -149,13 +149,13 @@ def test_assoc_legendre_full():
 def test_assoc_legengre_schmidt_identity():
     "Check Schmidt normalized functions against a known identity"
     # Higher degrees than this yield bad results
-    max_degree = 600
+    max_degree = 2800
     # The sum of the coefs squared for a degree should be 1
     true_value = np.ones(max_degree + 1)
     p = np.zeros((max_degree + 1, max_degree + 1))
     for x in np.linspace(-1, 1, 100):
         assoc_legendre_schmidt(x, max_degree, p)
-        np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-12)
+        np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-11, rtol=0)
 
 
 def test_assoc_legendre_deriv():

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -248,16 +248,16 @@ def test_assoc_legendre_full_deriv():
 
 
 @pytest.mark.parametrize(
-    "func,deriv,max_degree",
+    "func,deriv",
     (
-        (assoc_legendre, assoc_legendre_deriv, 10),
-        (assoc_legendre_schmidt, assoc_legendre_schmidt_deriv, 2800),
-        (assoc_legendre_full, assoc_legendre_full_deriv, 2800),
+        (assoc_legendre_schmidt, assoc_legendre_schmidt_deriv),
+        (assoc_legendre_full, assoc_legendre_full_deriv),
     ),
-    ids=["unnormalized", "schmidt", "full"],
+    ids=["schmidt", "full"],
 )
-def test_assoc_legengre_legendre_equation(func, deriv, max_degree):
+def test_assoc_legengre_legendre_equation(func, deriv):
     "Check functions and derivatives against the Legendre equation"
+    max_degree = 2800
     # Legendre equation should result in 0
     true_value = np.zeros((max_degree + 1, max_degree + 1))
     p = np.zeros((max_degree + 1, max_degree + 1))
@@ -274,5 +274,5 @@ def test_assoc_legengre_legendre_equation(func, deriv, max_degree):
         deriv(max_degree, dp, dp2)
         legendre = sin * dp2 + cos * dp + (sin * n * (n + 1) - m**2 / sin) * p
         np.testing.assert_allclose(
-            legendre, true_value, atol=1e-5, rtol=0, err_msg=f"angle={angle}"
+            legendre, true_value, atol=1e-7, rtol=0, err_msg=f"angle={angle}"
         )

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -152,10 +152,9 @@ def test_assoc_legengre_schmidt_identity():
     max_degree = 600
     # The sum of the coefs squared for a degree should be 1
     true_value = np.ones(max_degree + 1)
-    p = np.empty((max_degree + 1, max_degree + 1))
+    p = np.zeros((max_degree + 1, max_degree + 1))
     for x in np.linspace(-1, 1, 100):
         assoc_legendre_schmidt(x, max_degree, p)
-        p[np.isnan(p)] = 0
         np.testing.assert_allclose((p**2).sum(axis=1), true_value, atol=1e-12)
 
 

--- a/harmonica/tests/test_legendre.py
+++ b/harmonica/tests/test_legendre.py
@@ -64,9 +64,7 @@ def legendre_derivativeative_analytical(x):
     dp[3, 2] = 30 * cos**2 * sin - 15 * sin**3
     dp[3, 3] = 45 * sin**2 * cos
     dp[4, 0] = (15 * cos - 35 * cos**3) * sin / 2
-    dp[4, 1] = (
-        35 * cos**4 - 15 * cos**2 + 15 * sin**2 - 105 * cos**2 * sin**2
-    ) / 2
+    dp[4, 1] = (35 * cos**4 - 15 * cos**2 + 15 * sin**2 - 105 * cos**2 * sin**2) / 2
     dp[4, 2] = 105 * sin * cos**3 - 105 * cos * sin**3 - 15 * sin * cos
     dp[4, 3] = 315 * cos**2 * sin**2 - 105 * sin**4
     dp[4, 4] = 420 * sin**3 * cos

--- a/harmonica/tests/test_tesseroid.py
+++ b/harmonica/tests/test_tesseroid.py
@@ -633,13 +633,7 @@ def spherical_shell_analytical(top, bottom, density, radius):
     homogeneous spherical shell
     """
     potential = (
-        4
-        / 3
-        * np.pi
-        * GRAVITATIONAL_CONST
-        * density
-        * (top**3 - bottom**3)
-        / radius
+        4 / 3 * np.pi * GRAVITATIONAL_CONST * density * (top**3 - bottom**3) / radius
     )
     analytical = {
         "potential": potential,


### PR DESCRIPTION
Add a class to calculate the IGRF14 field. Uses Pooch to download IGRF14 from Zenodo. The class takes a date to instantiate and then calculates the field for that data through `predict` and `grid` methods. Inputs and outputs are in geocentric spherical coordinates by default but can be changed to geodetic if a Boule ellipsoid is given to the constructor.

**Relevant issues/PRs:** #504 
