### PR TITLE
Pin third-party Actions using commit hashes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,16 +59,11 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830
         with:
           python-version: ${{ env.PYTHON }}
           miniforge-version: latest
           channels: conda-forge
-          # Allow conda to use other than tar.bz2
-          # (otherwise it cannot find latest versions that
-          # don't use tar-bz2 files, see
-          # https://github.com/conda-incubator/setup-miniconda/issues/267)
-          use-only-tar-bz2: false
 
       - name: Collect requirements
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
         if: success() && github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
@@ -125,4 +125,4 @@ jobs:
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         run: ls -l -R .
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
         with:
           # Upload all coverage report files
           files: ./coverage_*/coverage.xml


### PR DESCRIPTION
For security, it's better to pin versions of third-party Actions to commit hashes. This is because the tags used for versions can be changed to point to a different (possibly malicious) commit while the hash can't. Dependabot can still update using the hashes so it's not a huge issue.