### PR TITLE
Solve import error of VTK in GitHub Actions

### DIFF
--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -13,7 +13,7 @@ ensaio>=0.5.*
 netcdf4
 matplotlib
 pyvista
-vtk>=9
+vtk==9.4.*
 pygmt
 gmt
 gdal

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - choclo>=0.1
   # Optional requirements
   - pyvista
-  - vtk
+  - vtk==9.4.*
   - numba-progress
   # Testing requirements
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - choclo>=0.1
   # Optional requirements
   - pyvista
-  - vtk==9.4.*
+  - vtk
   - numba-progress
   # Testing requirements
   - pytest


### PR DESCRIPTION
Constrain VTK to `9.4.*` in `requirements-docs.txt`.