### PR TITLE
Make ruff ignore sphinx-gallery builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ notice = '''
 line-length = 88
 exclude = [
     "doc/_build",
+    "doc/gallery",
     "src/choclo/_version.py",
 ]
 


### PR DESCRIPTION
The gallery builds Python scripts that don't always follow Ruff's style rules but they aren't really used in the final docs. Ruff checks the original gallery source code but it shouldn't these build products. Ignore them in the configuration.
