### PR TITLE
Fix the upload of coverage report to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,18 @@ jobs:
 
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # Need to fetch more than the last commit so that setuptools-scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
       - name: Download coverage report artifacts
         # Download coverage reports from every runner.
         # Maximum coverage is achieved by combining reports from every runner.


### PR DESCRIPTION
Checkout the repository in the codecov-upload job before uploading the coverage reports to codecov.
