### PR TITLE
Fix Ruff config to ignore of `_version.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ line-length = 88
 exclude = [
     "doc/_build",
     "doc/gallery",
-    "src/harmonica/_version.py",
+    "harmonica/_version.py",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Fix path to the `harmonica/_version.py` file in `pyproject.toml`.
