### PR TITLE
Upload built docs as artifacts on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -127,8 +127,7 @@ jobs:
 
       # Store the docs as a build artifact so we can deploy it later
       - name: Upload HTML documentation as an artifact
-        # Only if not a pull request
-        if: success() && github.event_name != 'pull_request'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: docs-${{ github.sha }}


### PR DESCRIPTION
Upload built docs as GitHub Actions artifacts on PRs, so we can download them and check them out locally before merging and without the need to build them locally.
