### PR TITLE
Drop the `macos-13` runner in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,14 +51,10 @@ jobs:
             python: "3.13"
           - dependencies: optional
             python: "3.13"
-          # test on macos-13 (x86) using oldest dependencies and python 3.8
-          - os: macos-13
+          # Include tests on macos (x86) with oldest dependencies
+          - os: macos-15-intel
             dependencies: oldest
             python: "3.10"
-        exclude:
-          # don't test on macos-latest (arm64) with oldest dependencies
-          - os: macos-latest
-            dependencies: oldest
 
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-tests.txt


### PR DESCRIPTION
Replace it by `macos-15-intel`, since `macos-13` has been deprecated, and causes large queue times.

**Relevant issues/PRs:**

Reference: https://github.com/actions/runner-images/issues/13046

