### PR TITLE
Remove the `defaults` channel when setting up Miniforge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,12 +58,13 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
-      - name: Setup Miniconda
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f
         with:
           python-version: ${{ env.PYTHON }}
           miniforge-version: latest
           channels: conda-forge
+          conda-remove-defaults: "true"
 
       - name: Collect requirements
         run: |


### PR DESCRIPTION
Explicitly remove the `defaults` channel when setting up Miniforge in the GitHub Action that builds the documentation. This way we ensure that we are using only `conda-forge` to download the required packages.
