### PR TITLE
Allow zizmor's ref-pinning of first-party actions

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# Configure zizmor
+# ================
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Allow to ref-pinning for first-party actions.
+        # Reference: https://docs.zizmor.sh/release-notes/#1200
+        actions/*: ref-pin
+        github/*: ref-pin
+        dependabot/*: ref-pin


### PR DESCRIPTION
Since zizmor 1.20.0, the default behaviour is that first-party actions (owned by GitHub) cannot be pinned by reference. Add a configuration file that allows to ref-pinning first-party actions to maintain the old behaviour.
