### PR TITLE
Temporarily pin `sklearn<1.8.0` in `.github/environment.yml`

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - scipy>=1.9
   # Pin sklearn to bypass issue with Verde 1.8.1 and sklearn 1.8.0. We should
   # fix this upstream and remove the upper constrain.
-  - scikit-learn>=1.1<1.8.0
+  - scikit-learn>=1.1,<1.8.0
   - numba>=0.57
   - xarray>=2022.03
   - verde>=1.8.1


### PR DESCRIPTION
Set an upper constrain for `skelarn` to bypass an issue involving Verde 1.8.1 and skelarn 1.8.0. We should fix this upstream and revert this commit in the future.
