### PR TITLE
Use `np.ravel` on input array due to Pandas 3.0.0

### DIFF
--- a/harmonica/_equivalent_sources/gradient_boosted.py
+++ b/harmonica/_equivalent_sources/gradient_boosted.py
@@ -222,9 +222,9 @@ class EquivalentSourcesGB(EquivalentSources):
         self.region_ = get_region(coordinates[:2])
         # Ravel coordinates, data and weights to 1d-arrays
         coordinates = vdb.n_1d_arrays(coordinates, 3)
-        data = data.ravel()
+        data = np.ravel(data)
         if weights is not None:
-            weights = weights.ravel()
+            weights = np.ravel(weights)
         # Build point sources
         if self.points is None:
             self.points_ = tuple(


### PR DESCRIPTION
Pandas 3.0.0 deprecated the `Series.ravel()` method, meaning that when a Series gets passed to a Harmonica function that needs to ravel it, it cannot do it through the `.ravel()` method. Instead, use the `np.ravel()` function that will ensure ravelling it, but also will always return a Numpy array.
