### PR TITLE
Use `codecov` environment in GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,7 @@ jobs:
   # Upload coverage report to codecov
   codecov-upload:
     runs-on: ubuntu-latest
+    environment: codecov
     needs: test
 
     steps:


### PR DESCRIPTION
Fix zizmor complain about setting secret through environmental variable without an `environment`: `secrets-outside-env`.
