### PR TITLE
Add link to citation information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 <p align="center">
 <a href="https://www.fatiando.org/harmonica"><strong>Documentation</strong> (latest)</a> •
-<a href="https://www.fatiando.org/harmonica/dev"><strong>Documentation</strong> (main branch)</a> •
-<a href="https://github.com/fatiando/harmonica/blob/main/CONTRIBUTING.md"><strong>Contributing</strong></a> •
+<a href="https://www.fatiando.org/harmonica/dev"><strong>Documentation</strong> (development)</a> •
+<a href="https://github.com/fatiando/harmonica/blob/main/CONTRIBUTING.md"><strong>Contribute</strong></a> •
 <a href="https://www.fatiando.org/contact/"><strong>Contact</strong></a> •
-<a href="https://github.com/orgs/fatiando/discussions"><strong>Ask a question</strong></a>
+<a href="https://github.com/orgs/fatiando/discussions"><strong>Ask a question</strong></a> •
+<a href="https://www.fatiando.org/harmonica/latest/citing.html"><strong>Cite</strong></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Also changed "Contributing" to "Contribute" for consistency and "main branch" to "development" to make it clearer that it's not the "main source of documentation".
