### PR TITLE
Increase fetch depth on PyPI Action to fix version numbers

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -39,7 +39,7 @@ jobs:
           # create the correct version string. If the number of commits since
           # the last release is greater than this, the version will still be
           # wrong. Increase if necessary.
-          fetch-depth: 100
+          fetch-depth: 200
           # The GitHub token is preserved by default but this job doesn't need
           # to be able to push to GitHub.
           persist-credentials: false


### PR DESCRIPTION
When we publish built packages to TestPyPI, the version number is wrong because we passed the 100 commit depth we had established earlier. When we do this, setuptools_scm can't find the last tag and then it can't generate the right version number. That's how we ended up with https://test.pypi.org/project/harmonica/0.0.post100/. Increase the depth so this doesn't happen. I don't think this would affect the version number for an actual release but it's best to be safe.