### PR TITLE
Make the README banner the h1 element

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="https://github.com/fatiando/harmonica/raw/main/doc/_static/readme-banner.png" alt="Harmonica">
+<h1><img src="https://github.com/fatiando/harmonica/raw/main/doc/_static/readme-banner.png" alt="Harmonica"></h1>
 
-<h2 align="center">Processing and modelling gravity and magnetic data</h2>
+<p align="center"><strong>Processing and modelling gravity and magnetic data</strong></p>
 
 <p align="center">
 <a href="https://www.fatiando.org/harmonica"><strong>Documentation</strong> (latest)</a> •


### PR DESCRIPTION
The README should follow standard HTML heading progressions. Before, we skipped the h1 heading and went straight to h2. Make the banner the h1 heading with an alt text. That means that the tag line shouldn't be an h2 as well but just a plain paragraph. We used the h2 for the font size but that's not ideal for accessibility.