### PR TITLE
Add `Ellipsoid.get_surface` method

### DIFF
--- a/src/harmonica/_forward/ellipsoids/ellipsoids.py
+++ b/src/harmonica/_forward/ellipsoids/ellipsoids.py
@@ -326,7 +326,7 @@ class Ellipsoid:
         ellipsoid.translate(self.center, inplace=True)
         return ellipsoid
 
-    def get_surface(self, *, size=181):
+    def get_surface(self, *, lon_size=361, lat_size=181):
         """
         Return three arrays with a discrete representation of the ellipsoid's surface.
 
@@ -336,9 +336,10 @@ class Ellipsoid:
 
         Parameters
         ----------
-        size : int, optional
+        lon_size : int, optional
             Number of points used in the latitudinal discretization.
-            Double of these points will be used in the longitudinal discretization.
+        lat_size : int, optional
+            Number of points used in the longitudinal discretization.
 
         Returns
         -------
@@ -364,8 +365,8 @@ class Ellipsoid:
         >>> plt.show()   # doctest: +SKIP
         """
         # Build longitude and latitude arrays
-        lon_rad = np.linspace(0, 2 * np.pi, 2 * size)
-        lat_rad = np.linspace(-np.pi / 2, np.pi / 2, size)
+        lon_rad = np.linspace(0, 2 * np.pi, lon_size)
+        lat_rad = np.linspace(-np.pi / 2, np.pi / 2, lat_size)
         lon_rad, lat_rad = np.meshgrid(lon_rad, lat_rad)
         shape = lon_rad.shape
 

--- a/src/harmonica/_forward/ellipsoids/ellipsoids.py
+++ b/src/harmonica/_forward/ellipsoids/ellipsoids.py
@@ -326,7 +326,7 @@ class Ellipsoid:
         ellipsoid.translate(self.center, inplace=True)
         return ellipsoid
 
-    def get_surface(self, *, size=151):
+    def get_surface(self, *, size=181):
         """
         Return three arrays with a discrete representation of the ellipsoid surface.
 

--- a/src/harmonica/_forward/ellipsoids/ellipsoids.py
+++ b/src/harmonica/_forward/ellipsoids/ellipsoids.py
@@ -325,3 +325,67 @@ class Ellipsoid:
         ellipsoid.rotate(rotation=self.rotation_matrix, inplace=True)
         ellipsoid.translate(self.center, inplace=True)
         return ellipsoid
+
+    def get_surface(self, *, size=151):
+        """
+        Return three arrays with a discrete representation of the ellipsoid surface.
+
+        .. tip::
+
+            Use this method to plot the ellipsoid in Matplotlib 3D plots.
+
+        Parameters
+        ----------
+        size : int, optional
+            Number of points used in the latitudinal discretization.
+            Double of these points will be used in the longitudinal discretization.
+
+        Returns
+        -------
+        easting, northing, upward : array
+            Arrays containing the coordinates of points in the surface of the ellipsoid.
+
+
+        Examples
+        --------
+        Use this method to plot the ellipsoid in matplotlib 3D plots:
+
+        >>> import matplotlib.pyplot as plt
+        >>>
+        >>> ellipsoid = Ellipsoid(a=3, b=2, c=1, yaw=60, pitch=45, roll=70)
+        >>>
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="3d")
+        >>> ax.plot_surface(*ellipsoid.get_surface()) # doctest: +SKIP
+        >>> ax.set_aspect("equal")
+        >>> ax.set_xlabel("x") # doctest: +SKIP
+        >>> ax.set_ylabel("y") # doctest: +SKIP
+        >>> ax.set_zlabel("z") # doctest: +SKIP
+        >>> plt.show()   # doctest: +SKIP
+        """
+        # Build longitude and latitude arrays
+        lon_rad = np.linspace(0, 2 * np.pi, 2 * size)
+        lat_rad = np.linspace(-np.pi / 2, np.pi / 2, size)
+        lon_rad, lat_rad = np.meshgrid(lon_rad, lat_rad)
+        shape = lon_rad.shape
+
+        # Get surface of ellipsoid in the local coordinate system
+        x = self.a * np.cos(lon_rad) * np.cos(lat_rad)
+        y = self.b * np.sin(lon_rad) * np.cos(lat_rad)
+        z = self.c * np.sin(lat_rad)
+
+        # Rotate surface points into the easting-northing-upward coordinate system
+        points = np.vstack([x.ravel(), y.ravel(), z.ravel()])
+        easting, northing, upward = self.rotation_matrix @ points
+
+        # Translate the surface points
+        e_center, n_center, u_center = self.center
+        easting += e_center
+        northing += n_center
+        upward += u_center
+
+        # Reshape arrays to return 2D arrays for the surface points
+        easting, northing, upward = tuple(
+            c.reshape(shape) for c in (easting, northing, upward)
+        )
+        return easting, northing, upward

--- a/src/harmonica/_forward/ellipsoids/ellipsoids.py
+++ b/src/harmonica/_forward/ellipsoids/ellipsoids.py
@@ -328,7 +328,7 @@ class Ellipsoid:
 
     def get_surface(self, *, size=181):
         """
-        Return three arrays with a discrete representation of the ellipsoid surface.
+        Return three arrays with a discrete representation of the ellipsoid's surface.
 
         .. tip::
 

--- a/test/ellipsoids/test_ellipsoids.py
+++ b/test/ellipsoids/test_ellipsoids.py
@@ -380,3 +380,27 @@ class TestRepr:
             ")"
         )
         assert expected == repr(ellipsoid)
+
+    def test_get_surface(self, ellipsoid):
+        """
+        Test surface points by checking if they satisfy characteristic equation.
+        """
+        easting, northing, upward = ellipsoid.get_surface()
+        assert easting.ndim == 2
+        assert easting.shape == northing.shape == upward.shape
+
+        # Go to local coordinate system
+        e_center, n_center, u_center = ellipsoid.center
+        points = np.vstack(
+            [
+                easting.ravel() - e_center,
+                northing.ravel() - n_center,
+                upward.ravel() - u_center,
+            ]
+        )
+        x, y, z = ellipsoid.rotation_matrix.T @ points
+
+        # Compare with characteristic equation
+        np.testing.assert_allclose(
+            x**2 / self.a**2 + y**2 / self.b**2 + z**2 / self.c**2, 1.0
+        )


### PR DESCRIPTION
Add a method to the `Ellipsoid` class to extract a set of discrete points located on its surface. The main purpose of this method is to be able to plot the ellipsoid in libraries like Matplotlib. Add a test that checks if the surface points satisfy the characteristic equation of ellipsoids.
