### PR TITLE
Make magnetization direction required in public reduction_to_pole

### DIFF
--- a/src/harmonica/_transformations.py
+++ b/src/harmonica/_transformations.py
@@ -389,8 +389,8 @@ def reduction_to_pole(
     grid,
     inclination,
     declination,
-    magnetization_inclination=None,
-    magnetization_declination=None,
+    magnetization_inclination,
+    magnetization_declination,
     *,
     pad=True,
     pad_kwargs=None,
@@ -412,16 +412,10 @@ def reduction_to_pole(
         The inclination of the inducing Geomagnetic field.
     declination : float in degrees
         The declination of the inducing Geomagnetic field.
-    magnetization_inclination : float in degrees or None
-        The inclination of the total magnetization of the anomaly source. If
-        None, the ``magnetization_inclination`` will be set equal to the
-        ``inclination``, neglecting remanent magnetization and self
-        demagnetization. Default None.
+    magnetization_inclination : float in degrees
+        The inclination of the total magnetization of the anomaly source.
     magnetization_declination : float in degrees
-        The declination of the total magnetization of the anomaly source. If
-        None, the ``magnetization_declination`` will be set equal to the
-        ``declination``, neglecting remanent magnetization and self
-        demagnetization. Default None.
+        The declination of the total magnetization of the anomaly source.
     pad : bool, optional
         If True, will add padding to the grid before taking the Fourier Transform
         and applying the filter and remove it after the inverse Fourier Transform.

--- a/test/test_transformations.py
+++ b/test/test_transformations.py
@@ -553,6 +553,21 @@ def test_reduction_to_pole_dim_names(sample_potential):
     reduction_to_pole(renamed_dims_grid, 60, 45, 60, 45)
 
 
+def test_reduction_to_pole_magnetization_required(sample_potential):
+    """
+    The magnetization direction must be a required argument.
+
+    Making it required forces users to be explicit about the induced-only
+    magnetization assumption (see #440 and #661). It used to default to None on
+    the public ``reduction_to_pole`` function, which crashed deep inside the
+    kernel after #661 removed the None handling.
+    """
+    with pytest.raises(TypeError, match="magnetization_inclination"):
+        reduction_to_pole(sample_potential, 60, 45)
+    with pytest.raises(TypeError, match="magnetization_declination"):
+        reduction_to_pole(sample_potential, 60, 45, 60)
+
+
 class TestTotalGradientAmplitude:
     """
     Test total_gradient_amplitude function.


### PR DESCRIPTION
Completes #661 (which fixes #440).

### Problem
#661 made the magnetization inclination/declination **required** in `reduction_to_pole_kernel` and removed the code that filled in defaults when they were `None`. However, the **public** `reduction_to_pole` function in `_transformations.py` was missed — it still declared:

```python
magnetization_inclination=None,
magnetization_declination=None,
```

and passed those straight into the now-strict kernel. So the documented default usage (omitting the magnetization direction, as the docstring still described) crashes deep inside the kernel:

```python
>>> hm.reduction_to_pole(grid, inclination, declination)
TypeError: loop of ufunc does not support argument 0 of type NoneType which has no callable radians method
```

This is exactly the silent "induced-only magnetization" foot-gun that @leouieda wanted to remove in #440 — except now it is a crash with a confusing message rather than a clear, explicit requirement.

### Fix
Complete #661 on the public function:
- Make `magnetization_inclination` / `magnetization_declination` required arguments (remove the `=None` defaults).
- Drop the stale *"If None … will be set equal to the inclination/declination"* docstring text, mirroring the kernel docstring updated in #661.

Omitting the magnetization direction now raises a clear error at call time:
```
TypeError: reduction_to_pole() missing 2 required positional arguments:
'magnetization_inclination' and 'magnetization_declination'
```

### Verification
- All existing `reduction_to_pole` tests and gallery/user-guide examples already pass the magnetization angles explicitly (updated in #661), so they are unaffected.
- Added a regression test (`test_reduction_to_pole_magnetization_required`) asserting the arguments are required; it fails on `main` (the old cryptic `TypeError` message does not name the argument) and passes with this change.
- `test/test_transformations.py` + `test/test_filters.py`: 61 passed. `ruff check` / `ruff format --check` clean.