### PR TITLE
Patch eq sources tests to not use damping as None

### DIFF
--- a/test/test_eq_sources_cartesian.py
+++ b/test/test_eq_sources_cartesian.py
@@ -109,26 +109,9 @@ def fixture_coordinates_9x9(region):
 
 
 @run_only_with_numba
-@pytest.mark.parametrize(
-    ("damping", "dtype"),
-    [
-        (None, "default"),
-        (1e-12, "default"),
-        (1e-12, np.float32),
-        pytest.param(
-            None,
-            np.float32,
-            marks=pytest.mark.xfail(
-                reason=(
-                    "equivalent sources with f32 values + no damping became "
-                    "unstable after sklearn 1.6.0"
-                )
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("dtype", ["default", np.float32])
 def test_equivalent_sources_cartesian(
-    region, points, masses, coordinates, data, dtype, damping
+    region, points, masses, coordinates, data, dtype
 ):  # pragma: no cover (we don't track coverage with @run_only_with_numba)
     """
     Check that predictions are reasonable when interpolating from one grid to
@@ -138,8 +121,8 @@ def test_equivalent_sources_cartesian(
     atol = 1e-3 * vd.maxabs(data)
 
     # Fit the equivalent sources
-    kwargs = {"dtype": dtype} if dtype == "float32" else {}
-    eqs = EquivalentSources(damping=damping, **kwargs)
+    kwargs = {"dtype": dtype} if dtype != "default" else {}
+    eqs = EquivalentSources(damping=1e-12, **kwargs)
     eqs.fit(coordinates, data)
 
     # The interpolation should be perfect on the data points

--- a/test/test_eq_sources_spherical.py
+++ b/test/test_eq_sources_spherical.py
@@ -92,7 +92,7 @@ def test_equivalent_sources_spherical():  # pragma: no cover
     )
 
     # The interpolation should be perfect on the data points
-    eqs = EquivalentSourcesSph(relative_depth=500e3)
+    eqs = EquivalentSourcesSph(relative_depth=500e3, damping=1e-18)
     eqs.fit(coordinates, data)
     npt.assert_allclose(data, eqs.predict(coordinates), rtol=1.3e-5, atol=1e-11)
 
@@ -135,7 +135,7 @@ def test_equivalent_sources_small_data_spherical():
     )
 
     # The interpolation should be perfect on the data points
-    eqs = EquivalentSourcesSph(relative_depth=500e3)
+    eqs = EquivalentSourcesSph(relative_depth=500e3, damping=1e-12)
     eqs.fit(coordinates, data)
     npt.assert_allclose(data, eqs.predict(coordinates), rtol=1e-5)
 

--- a/test/test_gradient_boosted_eqs.py
+++ b/test/test_gradient_boosted_eqs.py
@@ -183,7 +183,9 @@ def test_gradient_boosted_eqs_single_window(
     Test GB eq-sources with a single window that covers the whole region.
     """
     atol = 5e-8
-    eqs = EquivalentSourcesGB(depth=500, window_size=region[1] - region[0])
+    eqs = EquivalentSourcesGB(
+        depth=500, window_size=region[1] - region[0], damping=1e-18
+    )
     eqs.fit(coordinates, data)
     npt.assert_allclose(data, eqs.predict(coordinates), rtol=1e-5, atol=atol)
     # Gridding onto a denser grid should be reasonably accurate when compared
@@ -201,7 +203,9 @@ def test_gradient_boosted_eqs_predictions(
     Test GB eq-sources predictions.
     """
     # The interpolation should be sufficiently accurate on the data points
-    eqs = EquivalentSourcesGB(window_size=1e3, depth=1e3, damping=None, random_state=42)
+    eqs = EquivalentSourcesGB(
+        window_size=1e3, depth=1e3, damping=1e-24, random_state=42
+    )
     eqs.fit(coordinates, data)
     # Error tolerance is 2% of the maximum data.
     npt.assert_allclose(


### PR DESCRIPTION
Patch some of the equivalent sources tests that were failing on Numpy 2.4, probably due to different solutions for the ill-posed problem that is generated when `damping` is None.

**Relevant issues/PRs:**

Closes #687
