### PR TITLE
Restore upload of built docs as artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,3 +88,11 @@ jobs:
           sleep 3
           # Build the docs
           make -C doc clean all
+
+      # Store the docs as a build artifact so we can deploy it later
+      - name: Upload HTML documentation as an artifact
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-${{ github.sha }}
+          path: doc/_build/html


### PR DESCRIPTION
Restore the upload of built docs as artifacts in pull requests, removed in #679.
