### PR TITLE
Improve error messages on missing optional dependencies

### DIFF
--- a/src/harmonica/_forward/ellipsoids/ellipsoids.py
+++ b/src/harmonica/_forward/ellipsoids/ellipsoids.py
@@ -308,8 +308,15 @@ class Ellipsoid:
         ellipsoid : pyvista.PolyData
             A PyVista's parametric ellipsoid.
         """
-        # Lazy load optional dependency
-        import pyvista  # noqa: PLC0415
+        # Lazily load optional dependency
+        try:
+            import pyvista  # noqa: PLC0415
+        except ModuleNotFoundError as original:  # pragma: nocover
+            error = ImportError(
+                "Cannot import the optional dependency 'pyvista'. "
+                "It must be installed to run the 'to_pyvista' method."
+            )  # pragma: nocover
+            raise error from original  # pragma: nocover
 
         ellipsoid = pyvista.ParametricEllipsoid(
             xradius=self.a, yradius=self.b, zradius=self.c, **kwargs

--- a/src/harmonica/_forward/utils.py
+++ b/src/harmonica/_forward/utils.py
@@ -382,7 +382,7 @@ def initialize_progressbar(total, use_progressbar):
     # Lazily load optional dependency
     try:
         from numba_progress import ProgressBar  # noqa: PLC0415
-    except ImportError as original:  # pragma: nocover
+    except ModuleNotFoundError as original:  # pragma: nocover
         error = ImportError(
             "Cannot import the optional dependency 'numba_progress'. "
             "It must be installed to be able to show a progressbar."

--- a/src/harmonica/visualization/_prism.py
+++ b/src/harmonica/visualization/_prism.py
@@ -64,9 +64,16 @@ def prism_to_pyvista(prisms, properties=None):
        >>> pv_grid.plot() # doctest: +SKIP
 
     """
-    # Lazily import optional dependencies
-    import pyvista  # noqa: PLC0415
-    import vtk  # noqa: PLC0415
+    # Lazily load optional dependency
+    try:
+        import pyvista  # noqa: PLC0415
+        import vtk  # noqa: PLC0415
+    except ModuleNotFoundError as original:  # pragma: nocover
+        error = ImportError(
+            "Cannot import the optional dependency 'pyvista'. "
+            "It must be installed to run the 'prisms_to_pyvista' function."
+        )  # pragma: nocover
+        raise error from original  # pragma: nocover
 
     # Get prisms and number of prisms
     prisms = np.atleast_2d(prisms)


### PR DESCRIPTION
Fix the exceptions when lazy loading the optional dependencies to catch a `ModuleNotFoundError` instead of an `ImportError`. Add custom errors to imports of `pyvista` as well.

**Relevant issues/PRs:**

Addressing a comment raised by @mdtanker in #692.
